### PR TITLE
SrpConf was not implementing defmt::Format

### DIFF
--- a/openthread/Cargo.toml
+++ b/openthread/Cargo.toml
@@ -27,7 +27,7 @@ isupper = [] # Provide internal implementation of the `isupper` C fn
 [dependencies]
 openthread-sys = { path = "../openthread-sys" }
 log = { version = "0.4", default-features = false, optional = true }
-defmt = { version = "0.3", default-features = false, optional = true }
+defmt = { version = "0.3", default-features = false, optional = true, features = ["ip_in_core"] }
 scopeguard = { version = "1", default-features = false }
 rand_core = "0.6"
 embassy-sync = "0.6"


### PR DESCRIPTION
... due to a forgotten `&[Ipv6Addr]` inside, where `core::net::Ipv6Addr` does not implement `defmt::Format`.

The fix is a bit of a hack as I use the `defmt(Debug2Format)` annotation to fix this, BUT - I've given up - for now - on providing proper `defmt::Format` for all of `core::net` in all of `edge-net`, `rs-matter`, `rs-matter-stack`, `rs-matter-embassy`, because it is a gigantic task.

... because I either have to implement newtypes for `core::net`, or manually derive `defmt::Format` for any structure containing a `core::net` type (usually, `Ipv?Addr`). Needless to say, the above crates (esp. the `edge-net` ones) contain a lot of these.