### PR TITLE
Lower the log level of big or chatty log messages to trace

### DIFF
--- a/openthread-sys/src/lib.rs
+++ b/openthread-sys/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(unknown_lints)]
 
 pub use bindings::*;
 
@@ -7,6 +8,7 @@ pub use bindings::*;
     non_snake_case,
     non_upper_case_globals,
     dead_code,
+    unnecessary_transmutes,
     clippy::all
 )]
 pub mod bindings {

--- a/openthread/src/esp.rs
+++ b/openthread/src/esp.rs
@@ -113,7 +113,7 @@ impl Radio for EspRadio<'_> {
     ) -> Result<Option<PsduMeta>, Self::Error> {
         TX_SIGNAL.reset();
 
-        debug!(
+        trace!(
             "ESP Radio, about to transmit: {} on channel {}",
             Bytes(psdu),
             self.config.channel
@@ -149,7 +149,7 @@ impl Radio for EspRadio<'_> {
         let psdu_len = (raw.data.len() - 1).min((raw.data[0] & 0x7f) as usize);
         psdu_buf[..psdu_len].copy_from_slice(&raw.data[1..][..psdu_len]);
 
-        debug!(
+        trace!(
             "ESP Radio, received: {} on channel {}",
             Bytes(&psdu_buf[..psdu_len]),
             raw.channel

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -1,7 +1,9 @@
 //! A safe API for OpenThread (`openthread-sys`)
 
 #![no_std]
+#![allow(unknown_lints)]
 #![allow(async_fn_in_trait)]
+#![allow(clippy::uninlined_format_args)]
 
 use core::cell::{RefCell, RefMut};
 use core::ffi::c_void;
@@ -620,12 +622,12 @@ impl<'a> OpenThread<'a> {
                             trace!("Alarm interrupted by a new alarm: {}", new_when);
                             when = new_when;
                         } else {
-                            debug!("Alarm cancelled");
+                            trace!("Alarm cancelled");
                             break;
                         }
                     }
                     Either::Second(_) => {
-                        debug!("Alarm triggered, notifying OT main loop");
+                        trace!("Alarm triggered, notifying OT main loop");
 
                         {
                             let mut ot = self.activate();
@@ -696,7 +698,7 @@ impl<'a> OpenThread<'a> {
             trace!("Waiting for radio command");
 
             let mut cmd = radio_cmd().await;
-            debug!("Got radio command: {:?}", cmd);
+            trace!("Got radio command: {:?}", cmd);
 
             // TODO: Borrow it from the resources
             let mut psdu_buf = [0_u8; OT_RADIO_FRAME_MAX_SIZE as usize];
@@ -755,7 +757,7 @@ impl<'a> OpenThread<'a> {
                                     );
                                 }
 
-                                debug!("Tx interrupted by new command: {:?}", new_cmd);
+                                trace!("Tx interrupted by new command: {:?}", new_cmd);
 
                                 cmd = new_cmd;
                             }
@@ -766,7 +768,7 @@ impl<'a> OpenThread<'a> {
 
                                 match result {
                                     Ok(maybe_ack_psdu_meta) => {
-                                        debug!("Tx done, ack frame: {:?}", maybe_ack_psdu_meta);
+                                        trace!("Tx done, ack frame: {:?}", maybe_ack_psdu_meta);
 
                                         let ack_frame_ptr =
                                             if let Some(ack_psdu_meta) = maybe_ack_psdu_meta {
@@ -794,7 +796,7 @@ impl<'a> OpenThread<'a> {
                                         }
                                     }
                                     Err(err) => {
-                                        debug!("Tx failed: {:?}", err);
+                                        trace!("Tx failed: {:?}", err);
 
                                         unsafe {
                                             otPlatRadioTxDone(
@@ -823,7 +825,7 @@ impl<'a> OpenThread<'a> {
 
                         match result {
                             Either::First(new_cmd) => {
-                                debug!("Rx interrupted by new command: {:?}", new_cmd);
+                                trace!("Rx interrupted by new command: {:?}", new_cmd);
 
                                 cmd = new_cmd;
                             }
@@ -835,7 +837,7 @@ impl<'a> OpenThread<'a> {
                                     Ok(rcv_psdu_meta) => {
                                         let rcv_psdu = &psdu_buf[..rcv_psdu_meta.len];
 
-                                        debug!(
+                                        trace!(
                                             "Rx done, got frame: {:?}, {}",
                                             rcv_psdu_meta,
                                             Bytes(rcv_psdu)
@@ -860,7 +862,7 @@ impl<'a> OpenThread<'a> {
                                         }
                                     }
                                     Err(err) => {
-                                        debug!("Rx failed: {:?}", err);
+                                        trace!("Rx failed: {:?}", err);
 
                                         // Reporting receive failure because we got a driver error
                                         unsafe {
@@ -1250,7 +1252,7 @@ impl<'a> OtContext<'a> {
             if res != otError_OT_ERROR_DROP {
                 ot!(res)?;
 
-                debug!("Transmitted IPv6 packet: {}", Bytes(packet));
+                trace!("Transmitted IPv6 packet: {}", Bytes(packet));
             } else {
                 // OpenThread will intentionally drop some multicast and ICMPv6 packets
                 // which are not required for the Thread network.

--- a/openthread/src/nrf.rs
+++ b/openthread/src/nrf.rs
@@ -75,7 +75,7 @@ where
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         if self.config != *config {
-            debug!("Setting radio config: {:?}", config);
+            trace!("Setting radio config: {:?}", config);
 
             self.config = config.clone();
             self.update_driver_config();
@@ -89,7 +89,7 @@ where
         psdu: &[u8],
         _ack_psdu_buf: Option<&mut [u8]>,
     ) -> Result<Option<PsduMeta>, Self::Error> {
-        debug!("NRF Radio, about to transmit: {}", Bytes(psdu));
+        trace!("NRF Radio, about to transmit: {}", Bytes(psdu));
 
         let mut packet = Packet::new();
         // TODO: `embassy-nrf` driver wants the PSDU without the CRC,
@@ -122,7 +122,7 @@ where
             let len = packet.len() as _;
             psdu_buf[..len].copy_from_slice(&packet);
 
-            debug!("NRF Radio, received: {}", Bytes(&psdu_buf[..len]));
+            trace!("NRF Radio, received: {}", Bytes(&psdu_buf[..len]));
 
             let lqi = packet.lqi();
             let rssi = lqi as _; // TODO: Convert LQI to RSSI

--- a/openthread/src/radio.rs
+++ b/openthread/src/radio.rs
@@ -783,7 +783,7 @@ impl Radio for ProxyRadio<'_> {
             req.psdu.clear();
             unwrap!(req.psdu.extend_from_slice(psdu));
 
-            debug!("ProxyRadio, transmit request sent: {:?}", req);
+            trace!("ProxyRadio, transmit request sent: {:?}", req);
 
             self.request.send_done();
         }
@@ -800,7 +800,7 @@ impl Radio for ProxyRadio<'_> {
 
         let resp = self.response.receive().await;
 
-        debug!("ProxyRadio, transmit response received: {:?}", resp);
+        trace!("ProxyRadio, transmit response received: {:?}", resp);
 
         let psdu_meta = (ack_psdu_buf.is_some() && !resp.psdu.is_empty()).then_some(PsduMeta {
             len: resp.psdu.len(),
@@ -838,7 +838,7 @@ impl Radio for ProxyRadio<'_> {
             req.config = self.config.clone();
             req.psdu.clear();
 
-            debug!("ProxyRadio, receive request sent: {:?}", req);
+            trace!("ProxyRadio, receive request sent: {:?}", req);
 
             self.request.send_done();
         }
@@ -855,7 +855,7 @@ impl Radio for ProxyRadio<'_> {
 
         let resp = self.response.receive().await;
 
-        debug!("ProxyRadio, receive response received: {:?}", resp);
+        trace!("ProxyRadio, receive response received: {:?}", resp);
 
         match resp.result {
             Ok(()) => {
@@ -1003,7 +1003,7 @@ impl PhyRadioRunner<'_> {
 
         response.result = result;
 
-        debug!("PhyRadioRunner, processed response: {:?}", response);
+        trace!("PhyRadioRunner, processed response: {:?}", response);
 
         response_sender.send_done();
 

--- a/openthread/src/settings.rs
+++ b/openthread/src/settings.rs
@@ -327,7 +327,7 @@ where
         index: usize,
         buf: &mut [u8],
     ) -> Result<Option<usize>, SettingsError> {
-        debug!("Getting key: {}, index: {}", key, index);
+        trace!("Getting key: {}, index: {}", key, index);
 
         let for_key = self.iter().filter(|setting| setting.0 == key);
         let setting = for_key
@@ -339,7 +339,7 @@ where
             let len = setting.1.len().min(buf.len());
             buf[..len].copy_from_slice(setting.1);
 
-            debug!(
+            trace!(
                 "Got key: {}, index: {}, value: {}",
                 key,
                 index,
@@ -347,7 +347,7 @@ where
             );
             Ok(Some(len))
         } else {
-            debug!("Key not found: {}, index: {}", key, index);
+            trace!("Key not found: {}, index: {}", key, index);
             Ok(None)
         }
     }
@@ -366,7 +366,7 @@ where
     /// - `Ok(())`: The setting was added
     /// - `Err(_)`: An error occurred, like out of storage space
     pub fn add(&mut self, key: u16, value: &[u8]) -> Result<(), SettingsError> {
-        debug!("Adding key: {}, value: {}", key, Bytes(value));
+        trace!("Adding key: {}, value: {}", key, Bytes(value));
 
         let len = RamSetting::HDR_LEN + value.len();
         if self.buffer.len() - self.len < len {
@@ -390,7 +390,7 @@ where
             self.changed_signal.signal(());
         }
 
-        debug!("Added key: {}", key);
+        trace!("Added key: {}", key);
         Ok(())
     }
 
@@ -407,7 +407,7 @@ where
     /// - `Ok(false)`: The setting was not found
     /// - `Err(_)`: An error occurred
     pub fn remove(&mut self, key: u16, index: Option<usize>) -> Result<bool, SettingsError> {
-        debug!("Removing key: {}, index: {:?}", key, index);
+        trace!("Removing key: {}, index: {:?}", key, index);
 
         let mut found = false;
         let mut buf = &mut self.buffer[..self.len];
@@ -434,7 +434,7 @@ where
                         self.changed_signal.signal(());
                     }
 
-                    debug!("Removed key: {}, index: {:?}", key, index);
+                    trace!("Removed key: {}, index: {:?}", key, index);
                     found = true;
 
                     current += 1;
@@ -448,7 +448,7 @@ where
         }
 
         if !found {
-            debug!("Key not found: {}, index: {:?}", key, index);
+            trace!("Key not found: {}, index: {:?}", key, index);
         }
 
         Ok(found)


### PR DESCRIPTION
- The formerly-`debug!` logs in `ProxyRadio` and particularly in `NrfRadio` are so chatty, that they are in fact generating delays which sometimes cause `openthread` to fail its connectivity to its router (as the NRF radio does a lot of stuff in software, and needs precise timings). They are also dominating the log output when it is set to `DEFMT_LOG=debug` making the ever-so more useful `rs-matter` debug log more difficult to examine
- The logs in the Settings storage, as well as from the Alarm impl were downgraded to `trace!` as well, as they are also chatty and don't have much usefulness anyway
- We need an extra rustc warning suppression on the bindings generated by bindgen or else recently nightly rustc complains on unnecessary transmutes in bindgen-generated code where we don't have means to remove these transmutes

UPDATE: We also now need `#![allow(clippy::uninlined_format_args)]` as recent rustc really wants us to write `info!("{foo}")` instead of `info!("{}", foo)` - yet - the former is not really supported by `defmt` and it is unclear if or when it would be supported.
