### PR TITLE
Initialize esp_alloc in esp examples

### DIFF
--- a/examples/esp/Cargo.toml
+++ b/examples/esp/Cargo.toml
@@ -38,7 +38,7 @@ embassy-time = "0.5"
 embassy-net = { version = "0.7", features = ["proto-ipv6", "medium-ip", "udp", "log"] }
 esp-hal = { version = "1", features = ["log-04", "unstable", "exception-handler"] }
 esp-rtos = { version = "0.2", features = ["esp-radio", "embassy"] }
-esp-alloc = { version = "0.9", optional = true }
+esp-alloc = { version = "0.9" }
 esp-backtrace = { version = "0.18.1", features = ["panic-handler", "println"] }
 esp-println = { version = "0.16.1", features = ["log-04"] }
 esp-radio = { version = "0.17", features = ["unstable", "ieee802154"] }

--- a/examples/esp/src/bin/basic_enet.rs
+++ b/examples/esp/src/bin/basic_enet.rs
@@ -61,6 +61,8 @@ esp_bootloader_esp_idf::esp_app_desc!();
 
 #[esp_rtos::main]
 async fn main(spawner: Spawner) {
+    esp_alloc::heap_allocator!(size:1024);
+
     esp_println::logger::init_logger_from_env();
 
     info!("Starting...");

--- a/examples/esp/src/bin/basic_udp.rs
+++ b/examples/esp/src/bin/basic_udp.rs
@@ -56,6 +56,8 @@ esp_bootloader_esp_idf::esp_app_desc!();
 
 #[esp_rtos::main]
 async fn main(spawner: Spawner) {
+    esp_alloc::heap_allocator!(size:1024);
+
     esp_println::logger::init_logger_from_env();
 
     info!("Starting...");

--- a/examples/esp/src/bin/srp.rs
+++ b/examples/esp/src/bin/srp.rs
@@ -64,6 +64,8 @@ esp_bootloader_esp_idf::esp_app_desc!();
 
 #[esp_rtos::main]
 async fn main(spawner: Spawner) {
+    esp_alloc::heap_allocator!(size: 1024);
+
     esp_println::logger::init_logger_from_env();
 
     info!("Starting...");


### PR DESCRIPTION
This PR fixes #47 

esp_alloc is needed for the esp examples to work.
This adds esp_alloc as a none-optional dependency to the esp example project.
The allocator is configured to a size of 1024 bytes. The examples currently allocate roughly half of that by default.