### PR TITLE
Introduce a cca param when transmitting; fix the driver caps reporting

### DIFF
--- a/examples/nrf/src/bin/basic_enet.rs
+++ b/examples/nrf/src/bin/basic_enet.rs
@@ -29,6 +29,7 @@ use heapless::Vec;
 
 use openthread::enet::{self, EnetDriver, EnetRunner};
 use openthread::nrf::{Ieee802154, NrfRadio};
+use openthread::sys::otRadioCaps;
 use openthread::{
     BytesFmt, EmbassyTimeTimer, OpenThread, OtResources, PhyRadioRunner, ProxyRadio,
     ProxyRadioResources, Radio, SimpleRamSettings,
@@ -77,6 +78,8 @@ const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET"
     "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
 };
 
+const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
+
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let mut config = embassy_nrf::config::Config::default();
@@ -109,10 +112,10 @@ async fn main(spawner: Spawner) {
 
     info!("About to spawn OT runner");
 
-    let mut radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
+    let radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
 
     let proxy_radio_resources = mk_static!(ProxyRadioResources, ProxyRadioResources::new());
-    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(radio.caps(), proxy_radio_resources);
+    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(proxy_radio_resources);
 
     // High-priority executor: EGU1_SWI0, priority level 7
     interrupt::EGU0_SWI0.set_priority(Priority::P7);
@@ -216,7 +219,7 @@ async fn main(spawner: Spawner) {
 #[embassy_executor::task]
 async fn run_enet_driver(
     mut runner: EnetRunner<'static, IPV6_PACKET_SIZE>,
-    radio: ProxyRadio<'static>,
+    radio: ProxyRadio<'static, NRF_RADIO_CAPS>,
 ) -> ! {
     runner.run(radio).await
 }

--- a/examples/nrf/src/bin/basic_udp.rs
+++ b/examples/nrf/src/bin/basic_udp.rs
@@ -22,6 +22,7 @@ use embassy_nrf::rng::Rng;
 use embassy_nrf::{bind_interrupts, peripherals, radio};
 
 use openthread::nrf::{Ieee802154, NrfRadio};
+use openthread::sys::otRadioCaps;
 use openthread::{
     BytesFmt, EmbassyTimeTimer, OpenThread, OtResources, OtUdpResources, PhyRadioRunner,
     ProxyRadio, ProxyRadioResources, Radio, SimpleRamSettings, UdpSocket,
@@ -70,6 +71,8 @@ const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET"
     "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
 };
 
+const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
+
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let mut config = embassy_nrf::config::Config::default();
@@ -98,10 +101,10 @@ async fn main(spawner: Spawner) {
 
     info!("About to spawn OT runner");
 
-    let mut radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
+    let radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
 
     let proxy_radio_resources = mk_static!(ProxyRadioResources, ProxyRadioResources::new());
-    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(radio.caps(), proxy_radio_resources);
+    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(proxy_radio_resources);
 
     // High-priority executor: EGU0_SWI0, priority level 7
     interrupt::EGU0_SWI0.set_priority(Priority::P7);
@@ -149,7 +152,7 @@ async fn main(spawner: Spawner) {
 }
 
 #[embassy_executor::task]
-async fn run_ot(ot: OpenThread<'static>, radio: ProxyRadio<'static>) -> ! {
+async fn run_ot(ot: OpenThread<'static>, radio: ProxyRadio<'static, NRF_RADIO_CAPS>) -> ! {
     ot.run(radio).await
 }
 

--- a/openthread/src/esp.rs
+++ b/openthread/src/esp.rs
@@ -6,8 +6,7 @@ use embassy_sync::signal::Signal;
 use esp_radio::ieee802154::{Config as EspConfig, Error};
 
 use crate::{
-    Capabilities, Cca, Config, MacCapabilities, OtRadioCaps, PsduMeta, Radio, RadioError,
-    RadioErrorKind,
+    Capabilities, Cca, Config, MacCapabilities, PsduMeta, Radio, RadioError, RadioErrorKind,
 };
 
 pub use esp_radio::ieee802154::Ieee802154;
@@ -88,17 +87,9 @@ impl<'a> EspRadio<'a> {
 impl Radio for EspRadio<'_> {
     type Error = Error;
 
-    fn caps(&mut self) -> Capabilities {
-        Capabilities::RX_WHEN_IDLE
-    }
+    const CAPS: Capabilities = Capabilities::ACK_TIMEOUT.union(Capabilities::CSMA_BACKOFF) /* TODO: Depends on coex being off .union(Capabilities::RX_WHEN_IDLE) */;
 
-    fn mac_caps(&mut self) -> MacCapabilities {
-        MacCapabilities::all()
-    }
-
-    fn ot_radio_caps(&mut self) -> OtRadioCaps {
-        OtRadioCaps::ACK_TIMEOUT | OtRadioCaps::CSMA_BACKOFF
-    }
+    const MAC_CAPS: MacCapabilities = MacCapabilities::all();
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         if self.config != *config {
@@ -114,6 +105,7 @@ impl Radio for EspRadio<'_> {
     async fn transmit(
         &mut self,
         psdu: &[u8],
+        _cca: bool,
         _ack_psdu_buf: Option<&mut [u8]>,
     ) -> Result<Option<PsduMeta>, Self::Error> {
         TX_SIGNAL.reset();

--- a/openthread/src/nrf.rs
+++ b/openthread/src/nrf.rs
@@ -55,14 +55,10 @@ impl<'a> NrfRadio<'a> {
 impl Radio for NrfRadio<'_> {
     type Error = Error;
 
-    fn caps(&mut self) -> Capabilities {
-        Capabilities::RX_WHEN_IDLE
-    }
+    const CAPS: Capabilities = Capabilities::empty();
 
-    fn mac_caps(&mut self) -> MacCapabilities {
-        // The NRF radio does not have any MAC offloading capabilities
-        MacCapabilities::empty()
-    }
+    // The NRF radio does not have any MAC offloading capabilities
+    const MAC_CAPS: MacCapabilities = MacCapabilities::empty();
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         if self.config != *config {
@@ -78,6 +74,7 @@ impl Radio for NrfRadio<'_> {
     async fn transmit(
         &mut self,
         psdu: &[u8],
+        _csma: bool,
         _ack_psdu_buf: Option<&mut [u8]>,
     ) -> Result<Option<PsduMeta>, Self::Error> {
         trace!("NRF Radio, about to transmit: {}", Bytes(psdu));


### PR DESCRIPTION
This PR is extending the `Radio::transmit` driver trait method with an extra parameter - `cca` which - when set to `true` - instructs the driver to attempt transmission with the currently setup CCA method.

This is necessary for having more stable OpenThread connections, as per the work done here: https://github.com/esp-rs/esp-hal/pull/5006

=====

Additionally, the PR is doing two cleanups of the code which got introduced by PR #50 :

#### `OpenThread::set_link_mode`

The current implementation of this method contains a pretty big hack which is transferring the rx_when_idle flag directly to the driver (because setting rx_when_idle in the "clean" way is not supported by OT for FTD devices).

(Having rx_when_idle = true is generally useful, or else we might miss frames sent by the other party and then the other party should re-try on the 802.15.4 level or UDP level etc.)

Worse, it is done with further delay hacks only AFTER OT did connect because setting it before that - as per the contributor's own words (or Claude) "messes up the timings during connect".

I don't think this "mess up" is normal though. For one, the binding of the ESP-IDF C driver into ESP-IDF's OpenThread port set the driver **unconditionally** to rx_when_idle = true. Therefore, this "timings messup" is rather an indication of issues in our 802.15.4 driver **itself**, which should not be fixed with such a big hack in the first place, as it gets even worse downstream: https://github.com/sysgrok/rs-matter-embassy/pull/30. I really don't want to merge this thing, as it is propagating the hack further.

What this PR does is to make the method impl just a simple delegation to the C OT API without any "workarounds" which should be implemented in the ESP 802.15.4 driver itself.

#### OtRadioCaps

This bitset was introduced into the driver trait without actually noticing, that the existing `Capabilities` bitset is trying to model **exactly the same thing** (except being a bit incomplete in its variants).

Therefore, `OtRadioCaps` is now removed, and its variants are merged into the existing `Capabilities` bitset.

Further, since neither `Capabilities` nor `MacCapabilities` are supposed to change during the lifetime of the driver, the two existing `caps(self)` and `mac_caps(self)` methods were replaced with `const`s.
