### PR TITLE
Inline tasklet processing after events and correct alarm wrapping

### DIFF
--- a/openthread-sys/gen/builder.rs
+++ b/openthread-sys/gen/builder.rs
@@ -181,6 +181,7 @@ impl OpenThreadBuilder {
             .cxxflag("-DOPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS=128");
 
         config
+            .define("OT_THREAD_VERSION", "1.1")
             .define("OT_LOG_LEVEL", "NOTE")
             .define("OT_FTD", "OFF")
             .define("OT_MTD", "ON")


### PR DESCRIPTION
This PR is doing three things

#### Inline immediate taskslet processing in a few OpenThread callbacks

Tasklets are now processed immediately after `otPlatRadioReceiveDone`, `otPlatRadioTxDone` and after an alarm triggers. This should decrease the latency of `openthread` a bit, and ensures that deferred radio commands (e.g. from MeshForwarder tasklets) are processed before the radio loop starts its next operation, reducing gaps where the radio is idle and fragments can be missed.

NOTE: As a side effect, I found and removed **more** rx_when_idle hacks introduced by #50.

#### Fix wrong computation of alarm millis

(Also found by Opus 4.6) 

Fx the alarm time computation to correctly handle u32 wrapping by computing the offset from current time in 32-bit wrapping space, rather than naively converting the truncated u32 back to a 64-bit Instant.

#### Reported Thread version set to 1.1

Given that we don't (yet) support later versions of the 802.15.4 frames, I think this is the right call, even if temporary.