### PR TITLE
style: consistently use the cargo::KEY=VALUE syntax

### DIFF
--- a/examples/esp/build.rs
+++ b/examples/esp/build.rs
@@ -1,9 +1,9 @@
 fn main() {
     linker_be_nice();
     // Uncomment to enable defmt support
-    //println!("cargo:rustc-link-arg=-Tdefmt.x");
+    //println!("cargo::rustc-link-arg=-Tdefmt.x");
     // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
-    println!("cargo:rustc-link-arg=-Tlinkall.x");
+    println!("cargo::rustc-link-arg=-Tlinkall.x");
 }
 
 #[allow(unused)]
@@ -37,7 +37,7 @@ fn linker_be_nice() {
     }
 
     println!(
-        "cargo:rustc-link-arg=--error-handling-script={}",
+        "cargo::rustc-link-arg=--error-handling-script={}",
         std::env::current_exe().unwrap().display()
     );
 }

--- a/examples/nrf/build.rs
+++ b/examples/nrf/build.rs
@@ -21,15 +21,15 @@ fn main() {
         .unwrap()
         .write_all(include_bytes!("memory.x"))
         .unwrap();
-    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo::rustc-link-search={}", out.display());
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
-    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo::rerun-if-changed=memory.x");
 
-    println!("cargo:rustc-link-arg-bins=--nmagic");
-    println!("cargo:rustc-link-arg-bins=-Tlink.x");
-    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo::rustc-link-arg-bins=--nmagic");
+    println!("cargo::rustc-link-arg-bins=-Tlink.x");
+    println!("cargo::rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/openthread-sys/build.rs
+++ b/openthread-sys/build.rs
@@ -58,7 +58,7 @@ fn main() -> Result<()> {
             bindings.display()
         );
 
-        println!("cargo:rustc-link-search={}", libs_dir.display());
+        println!("cargo::rustc-link-search={}", libs_dir.display());
 
         for entry in std::fs::read_dir(libs_dir)? {
             let entry = entry?;
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
                     file_name.trim_end_matches(".lib")
                 };
 
-                println!("cargo:rustc-link-lib=static={lib_name}");
+                println!("cargo::rustc-link-lib=static={lib_name}");
             }
         }
     }

--- a/openthread-sys/gen/builder.rs
+++ b/openthread-sys/gen/builder.rs
@@ -216,7 +216,7 @@ impl OpenThreadBuilder {
     /// Re-run the build script if the file or directory has changed.
     #[allow(unused)]
     pub fn track(file_or_dir: &Path) {
-        println!("cargo:rerun-if-changed={}", file_or_dir.display())
+        println!("cargo::rerun-if-changed={}", file_or_dir.display())
     }
 
     /// A heuristics (we don't have anything better) to signal to `bindgen` whether the GCC toolchain


### PR DESCRIPTION
Since this project uses a MSRV way above 1.77 it makes sense to use the new syntax over the single-colon variant. The project currently uses a mix of both, so this commit converts everything to the new syntax.