### PR TITLE
feat: add clang sysroot

### DIFF
--- a/examples/esp/Cargo.toml
+++ b/examples/esp/Cargo.toml
@@ -30,6 +30,8 @@ default = ["esp32c6"]
 esp32c6 = ["esp-rtos/esp32c6", "esp-radio/esp32c6", "esp-backtrace/esp32c6", "esp-println/esp32c6", "esp-bootloader-esp-idf/esp32c6"]
 esp32h2 = ["esp-rtos/esp32h2", "esp-radio/esp32h2", "esp-backtrace/esp32h2", "esp-println/esp32h2", "esp-bootloader-esp-idf/esp32h2"]
 
+force-generate-bindings = ["openthread/force-generate-bindings"]
+
 [dependencies]
 embassy-executor = "0.9"
 embassy-sync = "0.7"

--- a/openthread-sys/build.rs
+++ b/openthread-sys/build.rs
@@ -37,6 +37,7 @@ fn main() -> Result<()> {
         let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
         let builder = builder::OpenThreadBuilder::new(
+            false,
             crate_root_path.clone(),
             Some(target),
             Some(host),

--- a/openthread-sys/gen/sysroot/include/assert.h
+++ b/openthread-sys/gen/sysroot/include/assert.h
@@ -1,0 +1,22 @@
+// See: <https://en.cppreference.com/w/c/header/assert.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// This is inspired by Clang's implementation of <assert.h>.
+#ifdef NDEBUG
+# define assert(...) ((void)0)
+#else
+// We just delegate to the `otPlatAssertFail` function, which will be provided
+// by our platform implementation.
+// TODO: Actually set OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT to 1 so our
+//       platform can handle this!
+_Noreturn void otPlatAssertFail(const char *aFilename, int aLineNumber);
+# define assert(...) ((__VA_ARGS__) ? ((void)0) : otPlatAssertFail(__FILE__, __LINE__))
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/ctype.h
+++ b/openthread-sys/gen/sysroot/include/ctype.h
@@ -1,0 +1,14 @@
+// See: <https://en.cppreference.com/w/c/header/ctype.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int iscntrl(int c);
+int isprint(int c);
+int isupper(int c);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/errno.h
+++ b/openthread-sys/gen/sysroot/include/errno.h
@@ -1,0 +1,35 @@
+// See: <https://en.cppreference.com/w/c/header/errno.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// HACK: By defining this we tell OpenThread's spinel.c that we don't provide
+//       a `errno` macro. This makes our life slightly easier as long as we
+//       don't actually use `errno` at runtime.
+#define SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR 1
+
+#define EPERM 1
+#define ENOMEM 12
+#define EINVAL 22
+#define EPIPE 32
+#define ERANGE 34
+#define ENOBUFS 64
+#define EOVERFLOW 75
+#define EMSGSIZE 90
+#define EAFNOSUPPORT 97
+#define ENETDOWN 100
+#define ENETUNREACH 101
+#define ECONNABORTED 103
+#define ECONNRESET 104
+#define EISCONN 106
+#define ENOTCONN 107
+#define ETIMEDOUT 110
+#define ECONNREFUSED 111
+#define EHOSTDOWN 112
+#define EHOSTUNREACH 113
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/inttypes.h
+++ b/openthread-sys/gen/sysroot/include/inttypes.h
@@ -1,0 +1,12 @@
+// See: <https://en.cppreference.com/w/c/header/inttypes.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// This file only needs to exist for mbedtls.
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/stdarg.h
+++ b/openthread-sys/gen/sysroot/include/stdarg.h
@@ -1,0 +1,18 @@
+// See: <https://en.cppreference.com/w/c/header/stdarg.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define va_start(ap, param) __builtin_va_start(ap, param)
+#define va_end(ap) __builtin_va_end(ap)
+#define va_arg(ap, type) __builtin_va_arg(ap, type)
+
+#define va_copy(dest, src) __builtin_va_copy(dest, src)
+
+typedef __builtin_va_list va_list;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/stddef.h
+++ b/openthread-sys/gen/sysroot/include/stddef.h
@@ -1,0 +1,20 @@
+// See: <https://en.cppreference.com/w/c/header/stddef.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef __SIZE_TYPE__ size_t;
+
+#ifdef __cplusplus
+#define NULL __null
+#else
+#define NULL ((void*)0)
+#endif
+
+#define offsetof(t, d) __builtin_offsetof(t, d)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/stdio.h
+++ b/openthread-sys/gen/sysroot/include/stdio.h
@@ -1,0 +1,24 @@
+// See: <https://en.cppreference.com/w/c/header/stdio.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdarg.h>
+#include <stddef.h>
+
+// mbedtls uses `FILE` for one of its function declarations.
+// To ensure we're not actually using `FILE` at runtime we define it as an
+// opaque struct.
+typedef struct __forbidden_FILE FILE;
+
+// The following two functions are defined by our `snprintf.c` file in `gen/support`.
+
+int snprintf(char* s, size_t n, const char* format, ...);
+
+int vsnprintf(char* s, size_t n, const char* format, va_list arg);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/stdlib.h
+++ b/openthread-sys/gen/sysroot/include/stdlib.h
@@ -1,0 +1,16 @@
+// See: <https://en.cppreference.com/w/c/header/stdlib.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdarg.h>
+#include <stddef.h>
+
+// Called by both mbedtls and OpenThread in case of assertion failures.
+_Noreturn void exit(int status);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/string.h
+++ b/openthread-sys/gen/sysroot/include/string.h
@@ -1,0 +1,41 @@
+// See: <https://en.cppreference.com/w/c/header/string.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Since <string.h> has to define `NULL` and `size_t`, let's re-export the
+// contents of <stddef.h> here.
+#include <stddef.h>
+
+#define strcpy __builtin_strcpy
+#define strncpy __builtin_strncpy
+
+#define strlen __builtin_strlen
+#define strcmp __builtin_strcmp
+#define strncmp __builtin_strncmp
+#define strchr __builtin_strchr
+#define strrchr __builtin_strrchr
+#define strstr __builtin_strstr
+
+#define memcmp __builtin_memcmp
+
+// HACK:
+// We need memset to be a function rather than a macro because mbedtls
+// assigns it to a static variable. Clang doesn't allow built-in functions
+// to be called through a function pointer, so we have to wrap it.
+//
+// This can be changed to the macro version once we compile against
+// mbedtls-rs-sys instead of the vendored version included in OpenThread.
+// See: <https://github.com/esp-rs/openthread/issues/61>
+inline void* memset(void* s, int c, size_t n) {
+  return __builtin_memset(s, c, n);
+}
+
+#define memcpy __builtin_memcpy
+#define memmove __builtin_memmove
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/strings.h
+++ b/openthread-sys/gen/sysroot/include/strings.h
@@ -1,0 +1,12 @@
+// See: <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/strings.h.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// This file only needs to exist for tcplp.
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/sys/types.h
+++ b/openthread-sys/gen/sysroot/include/sys/types.h
@@ -1,0 +1,17 @@
+// See: <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_types.h.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// This file only needs to exist for tcplp.
+
+#include <stdint.h>
+
+// Newlib defines `off_t` as `__SLONGWORD_TYPE`.
+typedef long int off_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/gen/sysroot/include/time.h
+++ b/openthread-sys/gen/sysroot/include/time.h
@@ -1,0 +1,13 @@
+// See: <https://en.cppreference.com/w/c/header/time.html>
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Newlib defines `time_t` as `__SLONGWORD_TYPE`.
+typedef long int time_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/openthread-sys/src/lib.rs
+++ b/openthread-sys/src/lib.rs
@@ -1,3 +1,36 @@
+//! Low-level bindings to the OpenThread library.
+//!
+//! # External dependencies
+//!
+//! Openthread depends on functions from the C standard library. These are not
+//! provided directly by this crate, but are expected to be linked by the user
+//! in some way.
+//!
+//! The following functions are required:
+//!
+//! - `exit`
+//! - `iscntrl`
+//! - `isprint`
+//! - `memchr`
+//! - `memcmp`
+//! - `memcpy`
+//! - `memmove`
+//! - `memset`
+//! - `strchr`
+//! - `strcmp`
+//! - `strcpy`
+//! - `strlen`
+//! - `strncpy`
+//! - `strstr`
+//!
+//! The following functions are required, but this crate already provides an
+//! implementation for them:
+//!
+//! - `snprintf`
+//! - `vsnprintf`
+//!
+//! Note that this list is likely to change over time.
+
 #![no_std]
 #![allow(unknown_lints)]
 


### PR DESCRIPTION
Closes: #51

Verified by running the `srp` example on an esp32c6 while hosting the network using ot_cli on an esp32c5:

```
esp32c5> ot srp server host
srp-example-1b86624d.default.service.arpa.
    deleted: false
    addresses: [fd1f:<SNIP>:dc8b]
```

<details>
  <summary>Old progress updates</summary>

This PR is still not quite finished. The current status is that we can compile the library with the sysroot, but actually building the ESP example is failing due to linker issues. This is totally expected though.

Update 1:
Funnily enough the linker errors were caused by me not using `extern "C"` blocks in the headers. Since OpenThread is mostly C++ code it actually makes a difference for once.
So at this point the ESP examples both compile and link. I just need access to an ESP to test it on. Should be able to do that tomorrow.

There are some symbols like `exit` and the assertion fail handler `otPlatAssertFail` that we don't define yet. Apparently they aren't required for the examples. I'll have to dig into those a bit to see under what conditions we actually need them.

</details>
