### PR TITLE
Some one-liner fixes as per #53

### DIFF
--- a/examples/nrf/Cargo.lock
+++ b/examples/nrf/Cargo.lock
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-nrf"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d63429d74ab5786cde7c9dc9a0338ea162a4da95e204ac5345c5ae36831fdb"
+checksum = "de748eaafda21aab46925973e593f377ed4482e9f4de63a729c79a7b0e4a327a"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "nrf-pac"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d334027d6703534f2a80de0794ae435c0e029358d28278533d3935e69b221b01"
+checksum = "ae76c372d1838abeccf1d397688cd4bd90fe3213410c51cb74c6769fdf075067"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/examples/nrf/src/bin/basic_enet.rs
+++ b/examples/nrf/src/bin/basic_enet.rs
@@ -28,11 +28,10 @@ use embassy_nrf::{bind_interrupts, peripherals, radio};
 use heapless::Vec;
 
 use openthread::enet::{self, EnetDriver, EnetRunner};
-use openthread::nrf::{Ieee802154, NrfRadio};
-use openthread::sys::otRadioCaps;
+use openthread::nrf::{Ieee802154, NrfProxyRadio, NrfRadio};
 use openthread::{
-    BytesFmt, EmbassyTimeTimer, OpenThread, OtResources, PhyRadioRunner, ProxyRadio,
-    ProxyRadioResources, Radio, SimpleRamSettings,
+    BytesFmt, EmbassyTimeTimer, OpenThread, OtResources, PhyRadioRunner, ProxyRadioResources,
+    SimpleRamSettings,
 };
 
 use rand_core::RngCore;
@@ -78,8 +77,6 @@ const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET"
     "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
 };
 
-const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
-
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let mut config = embassy_nrf::config::Config::default();
@@ -115,7 +112,7 @@ async fn main(spawner: Spawner) {
     let radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
 
     let proxy_radio_resources = mk_static!(ProxyRadioResources, ProxyRadioResources::new());
-    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(proxy_radio_resources);
+    let (proxy_radio, phy_radio_runner) = NrfProxyRadio::new(proxy_radio_resources);
 
     // High-priority executor: EGU1_SWI0, priority level 7
     interrupt::EGU0_SWI0.set_priority(Priority::P7);
@@ -219,7 +216,7 @@ async fn main(spawner: Spawner) {
 #[embassy_executor::task]
 async fn run_enet_driver(
     mut runner: EnetRunner<'static, IPV6_PACKET_SIZE>,
-    radio: ProxyRadio<'static, NRF_RADIO_CAPS>,
+    radio: NrfProxyRadio<'static>,
 ) -> ! {
     runner.run(radio).await
 }

--- a/examples/nrf/src/bin/basic_udp.rs
+++ b/examples/nrf/src/bin/basic_udp.rs
@@ -21,11 +21,10 @@ use embassy_nrf::mode::Blocking;
 use embassy_nrf::rng::Rng;
 use embassy_nrf::{bind_interrupts, peripherals, radio};
 
-use openthread::nrf::{Ieee802154, NrfRadio};
-use openthread::sys::otRadioCaps;
+use openthread::nrf::{Ieee802154, NrfProxyRadio, NrfRadio};
 use openthread::{
     BytesFmt, EmbassyTimeTimer, OpenThread, OtResources, OtUdpResources, PhyRadioRunner,
-    ProxyRadio, ProxyRadioResources, Radio, SimpleRamSettings, UdpSocket,
+    ProxyRadioResources, SimpleRamSettings, UdpSocket,
 };
 
 use panic_rtt_target as _;
@@ -71,8 +70,6 @@ const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET"
     "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
 };
 
-const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
-
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let mut config = embassy_nrf::config::Config::default();
@@ -104,7 +101,7 @@ async fn main(spawner: Spawner) {
     let radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
 
     let proxy_radio_resources = mk_static!(ProxyRadioResources, ProxyRadioResources::new());
-    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(proxy_radio_resources);
+    let (proxy_radio, phy_radio_runner) = NrfProxyRadio::new(proxy_radio_resources);
 
     // High-priority executor: EGU0_SWI0, priority level 7
     interrupt::EGU0_SWI0.set_priority(Priority::P7);
@@ -152,7 +149,7 @@ async fn main(spawner: Spawner) {
 }
 
 #[embassy_executor::task]
-async fn run_ot(ot: OpenThread<'static>, radio: ProxyRadio<'static, NRF_RADIO_CAPS>) -> ! {
+async fn run_ot(ot: OpenThread<'static>, radio: NrfProxyRadio<'static>) -> ! {
     ot.run(radio).await
 }
 

--- a/examples/nrf/src/bin/srp.rs
+++ b/examples/nrf/src/bin/srp.rs
@@ -25,11 +25,10 @@ use embassy_nrf::mode::Blocking;
 use embassy_nrf::rng::Rng;
 use embassy_nrf::{bind_interrupts, peripherals, radio};
 
-use openthread::nrf::{Ieee802154, NrfRadio};
-use openthread::sys::otRadioCaps;
+use openthread::nrf::{Ieee802154, NrfProxyRadio, NrfRadio};
 use openthread::{
     BytesFmt, EmbassyTimeTimer, OpenThread, OtResources, OtSrpResources, OtUdpResources,
-    PhyRadioRunner, ProxyRadio, ProxyRadioResources, Radio, SimpleRamSettings, SrpConf, UdpSocket,
+    PhyRadioRunner, ProxyRadioResources, SimpleRamSettings, SrpConf, UdpSocket,
 };
 
 use panic_rtt_target as _;
@@ -78,8 +77,6 @@ const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET"
     "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
 };
 
-const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
-
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let mut config = embassy_nrf::config::Config::default();
@@ -122,7 +119,7 @@ async fn main(spawner: Spawner) {
     let radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
 
     let proxy_radio_resources = mk_static!(ProxyRadioResources, ProxyRadioResources::new());
-    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(proxy_radio_resources);
+    let (proxy_radio, phy_radio_runner) = NrfProxyRadio::new(proxy_radio_resources);
 
     // High-priority executor: EGU0_SWI0, priority level 7
     interrupt::EGU0_SWI0.set_priority(Priority::P7);
@@ -205,7 +202,7 @@ async fn main(spawner: Spawner) {
 }
 
 #[embassy_executor::task]
-async fn run_ot(ot: OpenThread<'static>, radio: ProxyRadio<'static, NRF_RADIO_CAPS>) -> ! {
+async fn run_ot(ot: OpenThread<'static>, radio: NrfProxyRadio<'static>) -> ! {
     ot.run(radio).await
 }
 

--- a/openthread/src/esp.rs
+++ b/openthread/src/esp.rs
@@ -49,10 +49,10 @@ impl<'a> EspRadio<'a> {
             txpower: config.power,
             channel: config.channel,
             cca_threshold: match config.cca {
-                Cca::Carrier => 0,
-                Cca::Ed { ed_threshold } => ed_threshold as _,
-                Cca::CarrierAndEd { ed_threshold } => ed_threshold as _,
-                Cca::CarrierOrEd { ed_threshold } => ed_threshold as _,
+                Cca::Carrier => Cca::DEFAULT_ED_THRESHOLD_DBM,
+                Cca::Ed { ed_threshold } => ed_threshold,
+                Cca::CarrierAndEd { ed_threshold } => ed_threshold,
+                Cca::CarrierOrEd { ed_threshold } => ed_threshold,
             },
             cca_mode: match config.cca {
                 Cca::Carrier => esp_radio::ieee802154::CcaMode::Carrier,
@@ -89,12 +89,20 @@ impl<'a> EspRadio<'a> {
 impl Radio for EspRadio<'_> {
     type Error = RadioErrorKind;
 
+    // NOTE: Do NOT declare CSMA_BACKOFF here. The ESP32 hardware CcaTxStart
+    // only performs a single CCA check before transmitting. If CCA fails,
+    // the driver reports failure immediately with no backoff/retry.
+    // By omitting CSMA_BACKOFF, OpenThread's SubMac will handle CSMA/CA
+    // in software (random exponential backoff, multiple CCA retries).
     const CAPS: Capabilities = Capabilities::ACK_TIMEOUT
-        .union(Capabilities::CSMA_BACKOFF)
-        // .union(Capabilities::RX_ON_WHEN_IDLE) TODO: Depends on coex being off in ESP-IDF
+        .union(Capabilities::RX_ON_WHEN_IDLE) // TODO: Depends on coex being off in ESP-IDF
         ;
 
     const MAC_CAPS: MacCapabilities = MacCapabilities::all();
+
+    // Taken from the ESP-IDF driver
+    // https://github.com/espressif/esp-idf/blob/6f6766f917bc940ffbcc97eac4765a6ab15d5f79/components/openthread/src/port/esp_openthread_radio.c#L39
+    const RECEIVE_SENSITIVITY_DBM: i8 = -120;
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         if self.config != *config {

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -747,8 +747,12 @@ impl<'a> OpenThread<'a> {
         R: Radio,
         T: MacRadioTimer,
     {
-        // Fetch the radio capabilities from the driver
-        self.activate().state().ot.radio_caps = R::CAPS.bits();
+        // Fetch the radio capabilities and receive sensitivity from the driver
+        {
+            let mut active = self.activate();
+            active.state().ot.radio_caps = R::CAPS.bits();
+            active.state().ot.radio_receive_sensitivity = R::RECEIVE_SENSITIVITY_DBM;
+        }
 
         /// Fill the OpenThread frame structure based on the PSDU data returned by the radio
         fn fill_frame(
@@ -777,11 +781,18 @@ impl<'a> OpenThread<'a> {
 
             frame_psdu[..psdu.len()].copy_from_slice(psdu);
             frame.mLength = psdu.len() as _;
-            frame.mRadioType = 1; // TODO: Figure out what is this
+            frame.mRadioType = 0; // Radio 802.15.4 (trel is 1)
             frame.mChannel = psdu_meta.channel;
             frame.mInfo.mRxInfo.mRssi = rssi;
             frame.mInfo.mRxInfo.mLqi = rssi_to_lqi(rssi);
             frame.mInfo.mRxInfo.mTimestamp = Instant::now().as_micros(); // TODO: Not precise
+            frame.mInfo.mRxInfo.mAckFrameCounter = 0;
+            frame.mInfo.mRxInfo.mAckKeyId = 0;
+
+            unsafe {
+                frame.mInfo.mRxInfo.set_mAckedWithFramePending(false);
+                frame.mInfo.mRxInfo.set_mAckedWithSecEnhAck(false);
+            }
         }
 
         let mut radio = MacRadio::new(radio, timer);
@@ -1148,6 +1159,7 @@ impl OtResources {
             radio: Signal::new(),
             radio_conf: Config::new(),
             radio_caps: OT_RADIO_CAPS_ACK_TIMEOUT as otRadioCaps,
+            radio_receive_sensitivity: -120, // Some meaningful default for an MCU
             pending_rx_when_idle: None,
         }));
 
@@ -1582,9 +1594,8 @@ impl<'a> OtContext<'a> {
         rssi
     }
 
-    // from https://github.com/espressif/esp-idf/blob/release/v5.3/components/openthread/src/port/esp_openthread_radio.c#L35
     fn plat_radio_receive_sensititivy(&mut self) -> i8 {
-        let sens = 0; // TODO
+        let sens = self.state().ot.radio_receive_sensitivity;
         trace!(
             "Plat radio receive sensitivity callback, sensitivity: {}",
             sens
@@ -1594,13 +1605,14 @@ impl<'a> OtContext<'a> {
     }
 
     fn plat_radio_get_promiscuous(&mut self) -> bool {
-        let promiscuous = false; // TODO
+        let state = self.state();
+
         trace!(
             "Plat radio get promiscuous callback, promiscuous: {}",
-            promiscuous
+            state.ot.radio_conf.promiscuous
         );
 
-        promiscuous
+        state.ot.radio_conf.promiscuous
     }
 
     fn plat_radio_enable(&mut self) -> Result<(), OtError> {
@@ -1882,6 +1894,9 @@ struct OtState<'a> {
     /// Radio capabilities reported to OpenThread via otPlatRadioGetCaps.
     /// Fetched from the actual radio trait in the `OpenThread::run` API.
     radio_caps: otRadioCaps,
+    /// Radio receive sensitivity reported to OpenThread via otPlatRadioReceiveSensitivity
+    /// Fetched from the actual radio trait in the `OpenThread::run` API
+    radio_receive_sensitivity: i8,
     /// Deferred rx_when_idle value from set_link_mode called before device connects.
     /// Applied automatically via plat_changed when the device role becomes connected.
     pending_rx_when_idle: Option<bool>,

--- a/openthread/src/nrf.rs
+++ b/openthread/src/nrf.rs
@@ -4,7 +4,8 @@ pub use embassy_nrf::radio::ieee802154::{Cca as RadioCca, Packet};
 
 use crate::fmt::Bytes;
 use crate::{
-    Capabilities, Cca, Config, MacCapabilities, PsduMeta, Radio, RadioError, RadioErrorKind,
+    otRadioCaps, Capabilities, Cca, Config, MacCapabilities, ProxyRadio, PsduMeta, Radio,
+    RadioError, RadioErrorKind,
 };
 
 pub use embassy_nrf::radio::ieee802154::Radio as Ieee802154;
@@ -44,9 +45,15 @@ impl<'a> NrfRadio<'a> {
         self.driver.set_channel(config.channel);
         self.driver.set_cca(match config.cca {
             Cca::Carrier => RadioCca::CarrierSense,
-            Cca::Ed { ed_threshold } => RadioCca::EnergyDetection { ed_threshold },
-            Cca::CarrierAndEd { ed_threshold } => RadioCca::EnergyDetection { ed_threshold },
-            Cca::CarrierOrEd { ed_threshold } => RadioCca::EnergyDetection { ed_threshold },
+            Cca::Ed { ed_threshold } => RadioCca::EnergyDetection {
+                ed_threshold: ed_threshold as _,
+            },
+            Cca::CarrierAndEd { ed_threshold } => RadioCca::EnergyDetection {
+                ed_threshold: ed_threshold as _,
+            },
+            Cca::CarrierOrEd { ed_threshold } => RadioCca::EnergyDetection {
+                ed_threshold: ed_threshold as _,
+            },
         });
         self.driver.set_transmission_power(config.power);
     }
@@ -59,6 +66,8 @@ impl Radio for NrfRadio<'_> {
 
     // The NRF radio does not have any MAC offloading capabilities
     const MAC_CAPS: MacCapabilities = MacCapabilities::empty();
+
+    const RECEIVE_SENSITIVITY_DBM: i8 = -100;
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         if self.config != *config {
@@ -125,3 +134,9 @@ impl Radio for NrfRadio<'_> {
         }
     }
 }
+
+const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
+const NRF_RADIO_RSENS: i8 = NrfRadio::RECEIVE_SENSITIVITY_DBM;
+
+/// A proxy radio type alias where the proxied radio is `NrfRadio`
+pub type NrfProxyRadio<'a> = ProxyRadio<'a, NRF_RADIO_CAPS, NRF_RADIO_RSENS>;

--- a/openthread/src/radio.rs
+++ b/openthread/src/radio.rs
@@ -68,25 +68,43 @@ impl RadioError for RadioErrorKind {
 }
 
 /// Carrier sense or Energy Detection (ED) mode.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Cca {
     /// Carrier sense
-    #[default]
     Carrier,
     /// Energy Detection / Energy Above Threshold
     Ed {
-        /// Energy measurements above this value mean that the channel is assumed to be busy.
-        /// Note the measurement range is 0..0xFF - where 0 means that the received power was
-        /// less than 10 dB above the selected receiver sensitivity. This value is not given in dBm,
-        /// but can be converted. See the nrf52840 Product Specification Section 6.20.12.4
-        /// for details.
-        ed_threshold: u8,
+        /// Energy measurements above this dBm value mean that the channel is assumed to be busy.
+        ed_threshold: i8,
     },
     /// Carrier sense or Energy Detection
-    CarrierOrEd { ed_threshold: u8 },
+    CarrierOrEd {
+        /// Energy measurements above this dBm value mean that the channel is assumed to be busy.
+        ed_threshold: i8,
+    },
     /// Carrier sense and Energy Detection
-    CarrierAndEd { ed_threshold: u8 },
+    CarrierAndEd {
+        /// Energy measurements above this dBm value mean that the channel is assumed to be busy.
+        ed_threshold: i8,
+    },
+}
+
+impl Cca {
+    /// Default CCA energy detection threshold in dBm
+    pub const DEFAULT_ED_THRESHOLD_DBM: i8 = -60;
+
+    pub const fn new() -> Self {
+        Self::Ed {
+            ed_threshold: Self::DEFAULT_ED_THRESHOLD_DBM,
+        }
+    }
+}
+
+impl Default for Cca {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 bitflags! {
@@ -153,8 +171,6 @@ pub struct Config {
     pub power: i8,
     /// Clear channel assessment (CCA) mode
     pub cca: Cca,
-    /// TBD
-    pub sfd: u8,
     /// Promiscuous mode (receive all frames regardless of address filtering)
     /// Disregarded if the radio is not capable of operating in promiscuous mode.
     pub promiscuous: bool,
@@ -180,8 +196,7 @@ impl Config {
             // Run with max power by default
             // TODO: Figure out how to have this specified by the user
             power: 20,
-            cca: Cca::Carrier,
-            sfd: 0,
+            cca: Cca::new(),
             promiscuous: false,
             // OpenThread can have bursts of incoming frames, so we need to receive during idle state to not miss them.
             rx_when_idle: true,
@@ -242,6 +257,9 @@ pub trait Radio {
     /// If some of these are missing, `OpenThread` will emulate them in software.
     const MAC_CAPS: MacCapabilities;
 
+    /// Radio receive sensitivity
+    const RECEIVE_SENSITIVITY_DBM: i8;
+
     /// Set the radio configuration.
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error>;
 
@@ -296,6 +314,8 @@ where
     const CAPS: Capabilities = T::CAPS;
 
     const MAC_CAPS: MacCapabilities = T::MAC_CAPS;
+
+    const RECEIVE_SENSITIVITY_DBM: i8 = T::RECEIVE_SENSITIVITY_DBM;
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         T::set_config(self, config).await
@@ -441,6 +461,8 @@ where
     const CAPS: Capabilities = R::CAPS;
 
     const MAC_CAPS: MacCapabilities = R::MAC_CAPS;
+
+    const RECEIVE_SENSITIVITY_DBM: i8 = R::RECEIVE_SENSITIVITY_DBM;
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         self.radio
@@ -700,7 +722,7 @@ impl Default for ProxyRadioResources {
 ///   by passing it to `OpenThread::run`
 /// - `PhyRadioRunner`, which is `Send` and therefore can be sent to a separate executor - to run the radio.
 ///   Invoke `PhyRadioRunner::run(<the-phy-radio>, <delay-provider>).await` in that separate executor.
-pub struct ProxyRadio<'a, const CAPS: otRadioCaps> {
+pub struct ProxyRadio<'a, const CAPS: otRadioCaps, const RSENS: i8> {
     /// The request channel to the PHY radio
     request: Sender<'a, CriticalSectionRawMutex, ProxyRadioRequest>,
     /// The response channel from the PHY radio
@@ -715,7 +737,7 @@ pub struct ProxyRadio<'a, const CAPS: otRadioCaps> {
     config: Config,
 }
 
-impl<'a, const CAPS: otRadioCaps> ProxyRadio<'a, CAPS> {
+impl<'a, const CAPS: otRadioCaps, const RSENS: i8> ProxyRadio<'a, CAPS, RSENS> {
     const INIT_REQUEST: [ProxyRadioRequest; 1] = [ProxyRadioRequest::new()];
     const INIT_RESPONSE: [ProxyRadioResponse; 1] = [ProxyRadioResponse::new()];
 
@@ -747,7 +769,7 @@ impl<'a, const CAPS: otRadioCaps> ProxyRadio<'a, CAPS> {
 
         let state = unsafe { resources.state.assume_init_mut() };
 
-        state.split::<CAPS>()
+        state.split::<CAPS, RSENS>()
     }
 
     /// Clear any cancelled response from the driver
@@ -763,7 +785,7 @@ impl<'a, const CAPS: otRadioCaps> ProxyRadio<'a, CAPS> {
     }
 }
 
-impl<const CAPS: otRadioCaps> Radio for ProxyRadio<'_, CAPS> {
+impl<const CAPS: otRadioCaps, const RSENS: i8> Radio for ProxyRadio<'_, CAPS, RSENS> {
     type Error = RadioErrorKind;
 
     const CAPS: Capabilities = Capabilities::from_bits_truncate(CAPS);
@@ -771,6 +793,8 @@ impl<const CAPS: otRadioCaps> Radio for ProxyRadio<'_, CAPS> {
     // ... because the actual PHY radio on the other side
     // of the pipe will be wrapped with `MacRadio` if it cannot do ACKs and filtering in hardware
     const MAC_CAPS: MacCapabilities = MacCapabilities::all();
+
+    const RECEIVE_SENSITIVITY_DBM: i8 = RSENS;
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         // There is no separate command for updating the configuration
@@ -1077,7 +1101,9 @@ impl<'a> ProxyRadioState<'a> {
     }
 
     /// Split the state into the proxy radio and the PHY radio runner.
-    fn split<const CAPS: otRadioCaps>(&mut self) -> (ProxyRadio<'_, CAPS>, PhyRadioRunner<'_>) {
+    fn split<const CAPS: otRadioCaps, const RSENS: i8>(
+        &mut self,
+    ) -> (ProxyRadio<'_, CAPS, RSENS>, PhyRadioRunner<'_>) {
         let (request_sender, request_receiver) = self.request.split();
         let (response_sender, response_receiver) = self.response.split();
 


### PR DESCRIPTION
* Switch the default radio conf to do Energy Detection instead of Carrier CCA; use -60dBm for Energy Detection threshold
* Introduce a new `const generic` on the Radio trait for radio sensitivity. Set it to -120dBm for the ESP driver
* Do NOT report `CSMA_BACKOFF` for the ESP radio as the radio does not natively support this (just a CCA detection)