### PR TITLE
Fix a wrong links value

### DIFF
--- a/openthread-sys/Cargo.toml
+++ b/openthread-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openthread-sys"
 version = "0.1.0"
 edition = "2021"
-links = "mbedtls"
+links = "openthread"
 license = "MIT OR Apache-2.0"
 resolver = "2"
 rust-version = "1.84"


### PR DESCRIPTION
A regression from #69. Though strictly speaking, we currently also link-in an mbedtls copy. To be changed once #70 is merged.