### PR TITLE
Options to control the size and usage patterns of the internal OT heap

### DIFF
--- a/openthread-sys/Cargo.toml
+++ b/openthread-sys/Cargo.toml
@@ -48,6 +48,36 @@ default = ["matter", "mbedtls-rs-sys"]
 mbedtls-rs-sys = ["dep:mbedtls-rs-sys"]
 
 # ---------------------------------------------------------------------------
+# MbedTLS memory management (`gen/features.rs::MbedTlsMem`, `gen/builder.rs`).
+#
+# By default OpenThread takes over MbedTLS's allocator, rewiring
+# `mbedtls_calloc`/`free` to its own fixed-size internal `Heap` buffer
+# (`OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`). That buffer is small and
+# non-growable, so memory-hungry scenarios (e.g. Matter + Thread coexistence,
+# where MbedTLS is shared with `rs-matter`) can run it out of memory.
+#
+# These features override that. They are additive: `mbedtls-mem-ext` wins over
+# everything, otherwise the largest active `mbedtls-mem-int-<N>` wins. They only
+# take effect with the external MbedTLS (`mbedtls-rs-sys`). Enabling any of them
+# forces an on-the-fly OpenThread rebuild (the committed prebuilt libraries are
+# built with the default management).
+# ---------------------------------------------------------------------------
+
+# Turn OpenThread's builtin MbedTLS memory management OFF: MbedTLS allocates via
+# the plain `calloc`/`free` symbols — i.e. the firmware's global allocator
+# (`esp-alloc`, etc.) — sharing one heap instead of a private fixed buffer.
+mbedtls-mem-ext = []
+
+# Keep builtin management but resize the internal MbedTLS heap buffer to N bytes
+# (both the DTLS and non-DTLS variants). Keep this list in sync with
+# `features::MBEDTLS_MEM_INT_SIZES`.
+mbedtls-mem-int-4096 = []
+mbedtls-mem-int-8192 = []
+mbedtls-mem-int-16384 = []
+mbedtls-mem-int-32768 = []
+mbedtls-mem-int-65536 = []
+
+# ---------------------------------------------------------------------------
 # Device-type / radio-location selection. These pick WHICH static archives are
 # linked (all are always built); they do not change the shared
 # `OPENTHREAD_CONFIG_*` knobs. Additive: absence means the default.

--- a/openthread-sys/Cargo.toml
+++ b/openthread-sys/Cargo.toml
@@ -48,34 +48,45 @@ default = ["matter", "mbedtls-rs-sys"]
 mbedtls-rs-sys = ["dep:mbedtls-rs-sys"]
 
 # ---------------------------------------------------------------------------
-# MbedTLS memory management (`gen/features.rs::MbedTlsMem`, `gen/builder.rs`).
+# Heap configuration (`gen/features.rs::HeapConfig`, `gen/builder.rs`).
 #
-# By default OpenThread takes over MbedTLS's allocator, rewiring
-# `mbedtls_calloc`/`free` to its own fixed-size internal `Heap` buffer
-# (`OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`). That buffer is small and
-# non-growable, so memory-hungry scenarios (e.g. Matter + Thread coexistence,
-# where MbedTLS is shared with `rs-matter`) can run it out of memory.
+# OpenThread keeps ONE fixed-size internal heap buffer
+# (`OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`), shared by OpenThread's own
+# code AND — when builtin MbedTLS management is on (the default) — by MbedTLS.
+# That buffer is small and non-growable, so memory-hungry scenarios (e.g. Matter
+# + Thread coexistence, where MbedTLS is shared with `rs-matter`) can run it out
+# of memory.
 #
-# These features override that. They are additive: `mbedtls-mem-ext` wins over
-# everything, otherwise the largest active `mbedtls-mem-int-<N>` wins. They only
-# take effect with the external MbedTLS (`mbedtls-rs-sys`). Enabling any of them
-# forces an on-the-fly OpenThread rebuild (the committed prebuilt libraries are
-# built with the default management).
+# Three independent axes tune this. Enabling any of them forces an on-the-fly
+# OpenThread rebuild (the committed prebuilt libraries use the default heap
+# config). The `heap-int-*` set is additive: the largest active size wins.
 # ---------------------------------------------------------------------------
 
-# Turn OpenThread's builtin MbedTLS memory management OFF: MbedTLS allocates via
-# the plain `calloc`/`free` symbols — i.e. the firmware's global allocator
-# (`esp-alloc`, etc.) — sharing one heap instead of a private fixed buffer.
-mbedtls-mem-ext = []
+# Redirect OpenThread's OWN heap usage to the global allocator
+# (`OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1`). The consumer MUST then provide
+# the `otPlatCAlloc`/`otPlatFree` symbols (forwarding to the firmware's global
+# allocator), exactly like the `calloc`/`free` MbedTLS needs — this crate does
+# not supply them. Independent of the MbedTLS backend.
+heap-ext-ot = []
 
-# Keep builtin management but resize the internal MbedTLS heap buffer to N bytes
-# (both the DTLS and non-DTLS variants). Keep this list in sync with
-# `features::MBEDTLS_MEM_INT_SIZES`.
-mbedtls-mem-int-4096 = []
-mbedtls-mem-int-8192 = []
-mbedtls-mem-int-16384 = []
-mbedtls-mem-int-32768 = []
-mbedtls-mem-int-65536 = []
+# Turn OpenThread's builtin MbedTLS management OFF: MbedTLS allocates via the
+# plain `calloc`/`free` symbols — i.e. the firmware's global allocator
+# (`esp-alloc`, etc.) — instead of OpenThread's internal buffer. Only effective
+# with the external MbedTLS (`mbedtls-rs-sys`).
+heap-ext-mbedtls = []
+
+# Resize OpenThread's internal heap buffer to N bytes (both the DTLS and
+# non-DTLS variants). Independent of the ext toggles — the internal buffer may
+# still be used by whichever consumer is not redirected to the global allocator.
+# Keep this list in sync with `features::HEAP_INT_SIZES`.
+heap-int-4096 = []
+heap-int-6144 = []
+heap-int-8192 = []
+heap-int-12288 = []
+heap-int-16384 = []
+heap-int-32768 = []
+heap-int-49152 = []
+heap-int-65536 = []
 
 # ---------------------------------------------------------------------------
 # Device-type / radio-location selection. These pick WHICH static archives are

--- a/openthread-sys/gen/builder.rs
+++ b/openthread-sys/gen/builder.rs
@@ -243,14 +243,67 @@ impl OpenThreadBuilder {
         // MbedTLS backend selection (the `mbedtls-rs-sys` feature, on by
         // default). When enabled, OpenThread is built against the external
         // MbedTLS provided by `mbedtls-rs-sys` (whose includes were added
-        // above), and OpenThread overrides MbedTLS's memory management to use
-        // its own allocator. When disabled, OpenThread compiles its own bundled
-        // MbedTLS (the `third_party/mbedtls` subtree) — `OT_EXTERNAL_MBEDTLS` is
-        // simply not set, which is OpenThread's default.
+        // above). When disabled, OpenThread compiles its own bundled MbedTLS
+        // (the `third_party/mbedtls` subtree) — `OT_EXTERNAL_MBEDTLS` is simply
+        // not set, which is OpenThread's default.
+        //
+        // MbedTLS memory management (the `mbedtls-mem-*` features; see
+        // `features::MbedTlsMem`):
+        //  - default (`BuiltinDefault`) / sized (`BuiltinSized`): OpenThread
+        //    takes over MbedTLS's allocator, rewiring `mbedtls_calloc`/`free` to
+        //    its own fixed-size internal `Heap` buffer
+        //    (`OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`). `BuiltinSized`
+        //    resizes that buffer.
+        //  - external (`External`): builtin management OFF, so MbedTLS allocates
+        //    through the global `calloc`/`free` (the firmware's global allocator,
+        //    e.g. `esp-alloc`) instead of a private fixed buffer — the escape
+        //    hatch when the fixed buffer is too small (e.g. Matter + Thread
+        //    coexistence sharing MbedTLS).
+        //
+        // Note: with the external MbedTLS, OpenThread's own default for
+        // `OT_BUILTIN_MBEDTLS_MANAGEMENT` would be OFF (it tracks
+        // `OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS`, which is 0 for external),
+        // so the builtin cases must request `ON` explicitly.
         if use_external_mbedtls {
-            config
-                .define("OT_EXTERNAL_MBEDTLS", "mbedtls")
-                .define("OT_BUILTIN_MBEDTLS_MANAGEMENT", "ON");
+            config.define("OT_EXTERNAL_MBEDTLS", "mbedtls");
+
+            match features::mbedtls_mem() {
+                features::MbedTlsMem::External => {
+                    config.define("OT_BUILTIN_MBEDTLS_MANAGEMENT", "OFF");
+                }
+                features::MbedTlsMem::BuiltinDefault => {
+                    config.define("OT_BUILTIN_MBEDTLS_MANAGEMENT", "ON");
+                }
+                features::MbedTlsMem::BuiltinSized(size) => {
+                    config.define("OT_BUILTIN_MBEDTLS_MANAGEMENT", "ON");
+                    // Override both the DTLS and non-DTLS internal heap sizes.
+                    // OpenThread picks one or the other depending on whether a
+                    // DTLS feature is compiled in; set both so the selected size
+                    // applies regardless.
+                    for define in [
+                        "OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE",
+                        "OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS",
+                    ] {
+                        config
+                            .cflag(format!("-D{define}={size}"))
+                            .cxxflag(format!("-D{define}={size}"));
+                    }
+                }
+            }
+        } else if !matches!(
+            features::mbedtls_mem(),
+            features::MbedTlsMem::BuiltinDefault
+        ) {
+            // The `mbedtls-mem-*` features only take effect with the external
+            // MbedTLS (`mbedtls-rs-sys`). The bundled-MbedTLS path is not
+            // exercised here and `mbedtls-mem-ext` there would route MbedTLS to
+            // global `calloc`/`free` symbols the consumer may not provide. Warn
+            // rather than silently ignore the selection.
+            println!(
+                "cargo::warning=openthread-sys: the `mbedtls-mem-*` features are ignored \
+                 without the `mbedtls-rs-sys` feature (external MbedTLS); using OpenThread's \
+                 bundled MbedTLS with its default memory management."
+            );
         }
 
         // Apply the feature-driven `OT_*` knobs: every exposed knob is reset to

--- a/openthread-sys/gen/builder.rs
+++ b/openthread-sys/gen/builder.rs
@@ -246,61 +246,66 @@ impl OpenThreadBuilder {
         // above). When disabled, OpenThread compiles its own bundled MbedTLS
         // (the `third_party/mbedtls` subtree) — `OT_EXTERNAL_MBEDTLS` is simply
         // not set, which is OpenThread's default.
-        //
-        // MbedTLS memory management (the `mbedtls-mem-*` features; see
-        // `features::MbedTlsMem`):
-        //  - default (`BuiltinDefault`) / sized (`BuiltinSized`): OpenThread
-        //    takes over MbedTLS's allocator, rewiring `mbedtls_calloc`/`free` to
-        //    its own fixed-size internal `Heap` buffer
-        //    (`OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`). `BuiltinSized`
-        //    resizes that buffer.
-        //  - external (`External`): builtin management OFF, so MbedTLS allocates
-        //    through the global `calloc`/`free` (the firmware's global allocator,
-        //    e.g. `esp-alloc`) instead of a private fixed buffer — the escape
-        //    hatch when the fixed buffer is too small (e.g. Matter + Thread
-        //    coexistence sharing MbedTLS).
-        //
-        // Note: with the external MbedTLS, OpenThread's own default for
-        // `OT_BUILTIN_MBEDTLS_MANAGEMENT` would be OFF (it tracks
-        // `OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS`, which is 0 for external),
-        // so the builtin cases must request `ON` explicitly.
         if use_external_mbedtls {
             config.define("OT_EXTERNAL_MBEDTLS", "mbedtls");
+        }
 
-            match features::mbedtls_mem() {
-                features::MbedTlsMem::External => {
-                    config.define("OT_BUILTIN_MBEDTLS_MANAGEMENT", "OFF");
-                }
-                features::MbedTlsMem::BuiltinDefault => {
-                    config.define("OT_BUILTIN_MBEDTLS_MANAGEMENT", "ON");
-                }
-                features::MbedTlsMem::BuiltinSized(size) => {
-                    config.define("OT_BUILTIN_MBEDTLS_MANAGEMENT", "ON");
-                    // Override both the DTLS and non-DTLS internal heap sizes.
-                    // OpenThread picks one or the other depending on whether a
-                    // DTLS feature is compiled in; set both so the selected size
-                    // applies regardless.
-                    for define in [
-                        "OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE",
-                        "OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS",
-                    ] {
-                        config
-                            .cflag(format!("-D{define}={size}"))
-                            .cxxflag(format!("-D{define}={size}"));
-                    }
-                }
+        // Heap configuration (the `heap-*` features; see `features::HeapConfig`).
+        // OpenThread has ONE fixed-size internal buffer shared by its own code
+        // and — when builtin MbedTLS management is on — by MbedTLS. The three
+        // axes below are independent: each ext toggle redirects one consumer to
+        // the global allocator, and the size knob sizes the internal buffer for
+        // whoever still uses it.
+        let heap = features::heap_config();
+
+        // `heap-int-<N>`: resize the internal buffer. Override both the DTLS and
+        // non-DTLS sizes (OpenThread picks one or the other depending on whether
+        // a DTLS feature is compiled in) so the selected size applies regardless.
+        // Applied whenever set, independently of the ext toggles.
+        if let Some(size) = heap.int_size {
+            for define in [
+                "OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE",
+                "OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS",
+            ] {
+                config
+                    .cflag(format!("-D{define}={size}"))
+                    .cxxflag(format!("-D{define}={size}"));
             }
-        } else if !matches!(
-            features::mbedtls_mem(),
-            features::MbedTlsMem::BuiltinDefault
-        ) {
-            // The `mbedtls-mem-*` features only take effect with the external
-            // MbedTLS (`mbedtls-rs-sys`). The bundled-MbedTLS path is not
-            // exercised here and `mbedtls-mem-ext` there would route MbedTLS to
-            // global `calloc`/`free` symbols the consumer may not provide. Warn
-            // rather than silently ignore the selection.
+        }
+
+        // `heap-ext-ot`: redirect OpenThread's *own* heap usage to the global
+        // allocator (`OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1`). This is a core
+        // OpenThread knob, independent of the MbedTLS backend. The consumer must
+        // provide `otPlatCAlloc`/`otPlatFree` at link time (forwarding to the
+        // firmware's global allocator), exactly like MbedTLS's `calloc`/`free`
+        // contract — the crate does not supply them.
+        if heap.ext_ot {
+            config
+                .cflag("-DOPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1")
+                .cxxflag("-DOPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1");
+        }
+
+        // `heap-ext-mbedtls`: turn OpenThread's builtin MbedTLS management off
+        // (`OT_BUILTIN_MBEDTLS_MANAGEMENT=OFF`) so MbedTLS allocates through the
+        // global `calloc`/`free` rather than the internal buffer. Only meaningful
+        // with the external MbedTLS.
+        //
+        // Note: with the external MbedTLS, OpenThread's own default for
+        // `OT_BUILTIN_MBEDTLS_MANAGEMENT` is already OFF (it tracks
+        // `OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS`, which is 0 for external), so
+        // when the feature is NOT set we must request `ON` explicitly to keep the
+        // historical shared-buffer behaviour.
+        if use_external_mbedtls {
+            config.define(
+                "OT_BUILTIN_MBEDTLS_MANAGEMENT",
+                if heap.ext_mbedtls { "OFF" } else { "ON" },
+            );
+        } else if heap.ext_mbedtls {
+            // The bundled-MbedTLS path is not exercised here and would route
+            // MbedTLS to global `calloc`/`free` symbols the consumer may not
+            // provide. Warn rather than silently ignore the selection.
             println!(
-                "cargo::warning=openthread-sys: the `mbedtls-mem-*` features are ignored \
+                "cargo::warning=openthread-sys: the `heap-ext-mbedtls` feature is ignored \
                  without the `mbedtls-rs-sys` feature (external MbedTLS); using OpenThread's \
                  bundled MbedTLS with its default memory management."
             );

--- a/openthread-sys/gen/features.rs
+++ b/openthread-sys/gen/features.rs
@@ -185,65 +185,64 @@ pub fn use_external_mbedtls() -> bool {
     std::env::var_os("CARGO_FEATURE_MBEDTLS_RS_SYS").is_some()
 }
 
-/// How OpenThread should manage the memory MbedTLS allocates.
+/// OpenThread keeps ONE general-purpose heap: a single fixed-size buffer baked
+/// into the firmware (`Instance::sHeap`, sized by
+/// `OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`), with OpenThread's own block
+/// allocator on top. Two consumers draw from it:
 ///
-/// By default OpenThread takes over MbedTLS's allocator
-/// (`OT_BUILTIN_MBEDTLS_MANAGEMENT=ON`): it rewires `mbedtls_calloc`/`free` to
-/// its *own* `ot::Heap`, which is a single fixed-size buffer baked into the
-/// firmware (`OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`). That buffer is
-/// small and non-growable, so in memory-hungry scenarios (e.g. Matter + Thread
-/// coexistence, where MbedTLS is shared between `rs-matter` and OpenThread)
-/// MbedTLS runs out of room.
+///  - OpenThread itself (`HeapData`/`HeapString`, SRP tables, network data, …),
+///    via `ot::Heap::CAlloc`.
+///  - MbedTLS, *if* OpenThread takes over MbedTLS's allocator
+///    (`OT_BUILTIN_MBEDTLS_MANAGEMENT=ON`, the default), which rewires
+///    `mbedtls_calloc`/`free` to that same `ot::Heap`.
 ///
-/// These cargo features let the consumer override that:
+/// So the buffer is small, non-growable, and SHARED. In memory-hungry scenarios
+/// (e.g. Matter + Thread coexistence, where MbedTLS is shared between
+/// `rs-matter` and OpenThread, and ECDSA scratch competes with OpenThread's own
+/// allocations) it runs out of room.
 ///
-///  - `mbedtls-mem-ext`: turn the builtin management OFF, so MbedTLS allocates
-///    via the plain `calloc`/`free` symbols (i.e. the global allocator the
-///    firmware already provides — `esp-alloc` on ESP, etc.), sharing one heap
-///    instead of a private fixed buffer.
-///  - `mbedtls-mem-int-<N>`: keep the builtin management but resize the internal
-///    buffer to `<N>` bytes (both the DTLS and NO_DTLS variants).
-///
-/// These are additive (cargo features are unioned across the dependency graph,
-/// so they cannot be made mutually exclusive). The selection rules:
-///  - `mbedtls-mem-ext` overrides everything — if it is active, MbedTLS goes to
-///    the global allocator and any `mbedtls-mem-int-<N>` is disregarded.
-///  - otherwise, if one or more `mbedtls-mem-int-<N>` are active, the *largest*
-///    size wins.
-pub enum MbedTlsMem {
-    /// Builtin management with OpenThread's own default buffer size (the
-    /// historical behaviour). No `mbedtls-mem-*` feature active.
-    BuiltinDefault,
-    /// Builtin management, internal buffer resized to this many bytes
-    /// (`mbedtls-mem-int-<N>`).
-    BuiltinSized(u32),
-    /// Builtin management OFF — MbedTLS uses the global `calloc`/`free`
-    /// (`mbedtls-mem-ext`).
-    External,
+/// Three independent feature axes tune this (see the accessors below). They are
+/// orthogonal: each ext toggle redirects ONE consumer away from the internal
+/// buffer to the global allocator, and the size knob sizes the internal buffer
+/// for whoever still uses it. None overrides another.
+pub struct HeapConfig {
+    /// `heap-ext-ot`: redirect OpenThread's *own* heap usage to the global
+    /// allocator (`OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1`). The consumer must
+    /// then provide `otPlatCAlloc`/`otPlatFree` (forwarding to whatever global
+    /// allocator the firmware has), exactly like MbedTLS's `calloc`/`free`
+    /// contract.
+    pub ext_ot: bool,
+    /// `heap-ext-mbedtls`: turn OpenThread's builtin MbedTLS management OFF
+    /// (`OT_BUILTIN_MBEDTLS_MANAGEMENT=OFF`), so MbedTLS allocates via the plain
+    /// `calloc`/`free` symbols (the firmware's global allocator) rather than
+    /// OpenThread's internal buffer. Only meaningful with the external MbedTLS.
+    pub ext_mbedtls: bool,
+    /// `heap-int-<N>`: resize the internal buffer to `Some(N)` bytes (both the
+    /// DTLS and NO_DTLS variants), or `None` to keep OpenThread's own default.
+    /// Applies whenever set, independently of the ext toggles, since the
+    /// internal buffer may still be used by whichever consumer is NOT redirected
+    /// to the global allocator.
+    pub int_size: Option<u32>,
 }
 
-/// The internal-buffer sizes (in bytes) exposed as `mbedtls-mem-int-<N>` cargo
-/// features. Keep in sync with the `mbedtls-mem-int-*` features in `Cargo.toml`
-/// (the build script's guard enforces it).
-pub const MBEDTLS_MEM_INT_SIZES: &[u32] = &[4096, 8192, 16384, 32768, 65536];
+/// The internal-buffer sizes (in bytes) exposed as `heap-int-<N>` cargo
+/// features. Keep in sync with the `heap-int-*` features in `Cargo.toml`.
+pub const HEAP_INT_SIZES: &[u32] = &[4096, 6144, 8192, 12288, 16384, 32768, 49152, 65536];
 
-/// Resolve the active `mbedtls-mem-*` selection from the `CARGO_FEATURE_*`
-/// environment, applying the additive override rules (see [`MbedTlsMem`]):
-/// `mbedtls-mem-ext` wins over everything; otherwise the largest active
-/// `mbedtls-mem-int-<N>` wins. Must only be called from within the build script.
-pub fn mbedtls_mem() -> MbedTlsMem {
-    if std::env::var_os("CARGO_FEATURE_MBEDTLS_MEM_EXT").is_some() {
-        return MbedTlsMem::External;
-    }
-
-    match MBEDTLS_MEM_INT_SIZES
-        .iter()
-        .copied()
-        .filter(|n| std::env::var_os(format!("CARGO_FEATURE_MBEDTLS_MEM_INT_{n}")).is_some())
-        .max()
-    {
-        Some(n) => MbedTlsMem::BuiltinSized(n),
-        None => MbedTlsMem::BuiltinDefault,
+/// Resolve the active heap configuration from the `CARGO_FEATURE_*` environment.
+/// The three axes are independent (see [`HeapConfig`]); the only "additive"
+/// rule is that, among multiple `heap-int-<N>`, the *largest* size wins (cargo
+/// features union across the dependency graph and cannot be made exclusive).
+/// Must only be called from within the build script.
+pub fn heap_config() -> HeapConfig {
+    HeapConfig {
+        ext_ot: std::env::var_os("CARGO_FEATURE_HEAP_EXT_OT").is_some(),
+        ext_mbedtls: std::env::var_os("CARGO_FEATURE_HEAP_EXT_MBEDTLS").is_some(),
+        int_size: HEAP_INT_SIZES
+            .iter()
+            .copied()
+            .filter(|n| std::env::var_os(format!("CARGO_FEATURE_HEAP_INT_{n}")).is_some())
+            .max(),
     }
 }
 
@@ -331,14 +330,19 @@ pub fn prebuilt_validity() -> Result<(), String> {
         parts.push("-mbedtls-rs-sys (bundled MbedTLS)".to_string());
     }
 
-    // The prebuilt is built with OpenThread's default MbedTLS memory management
-    // (`MbedTlsMem::BuiltinDefault`). Any `mbedtls-mem-*` override changes the
-    // compiled `.a` (the allocator wiring and/or the internal heap size), so it
-    // must force an on-the-fly rebuild.
-    match mbedtls_mem() {
-        MbedTlsMem::BuiltinDefault => {}
-        MbedTlsMem::BuiltinSized(n) => parts.push(format!("+mbedtls-mem-int-{n}")),
-        MbedTlsMem::External => parts.push("+mbedtls-mem-ext".to_string()),
+    // The prebuilt is built with OpenThread's default heap configuration (no
+    // `heap-*` feature). Any override changes the compiled `.a` (the allocator
+    // wiring and/or the internal heap size), so it must force an on-the-fly
+    // rebuild.
+    let heap = heap_config();
+    if heap.ext_ot {
+        parts.push("+heap-ext-ot".to_string());
+    }
+    if heap.ext_mbedtls {
+        parts.push("+heap-ext-mbedtls".to_string());
+    }
+    if let Some(n) = heap.int_size {
+        parts.push(format!("+heap-int-{n}"));
     }
 
     if parts.is_empty() {

--- a/openthread-sys/gen/features.rs
+++ b/openthread-sys/gen/features.rs
@@ -185,6 +185,68 @@ pub fn use_external_mbedtls() -> bool {
     std::env::var_os("CARGO_FEATURE_MBEDTLS_RS_SYS").is_some()
 }
 
+/// How OpenThread should manage the memory MbedTLS allocates.
+///
+/// By default OpenThread takes over MbedTLS's allocator
+/// (`OT_BUILTIN_MBEDTLS_MANAGEMENT=ON`): it rewires `mbedtls_calloc`/`free` to
+/// its *own* `ot::Heap`, which is a single fixed-size buffer baked into the
+/// firmware (`OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE[_NO_DTLS]`). That buffer is
+/// small and non-growable, so in memory-hungry scenarios (e.g. Matter + Thread
+/// coexistence, where MbedTLS is shared between `rs-matter` and OpenThread)
+/// MbedTLS runs out of room.
+///
+/// These cargo features let the consumer override that:
+///
+///  - `mbedtls-mem-ext`: turn the builtin management OFF, so MbedTLS allocates
+///    via the plain `calloc`/`free` symbols (i.e. the global allocator the
+///    firmware already provides — `esp-alloc` on ESP, etc.), sharing one heap
+///    instead of a private fixed buffer.
+///  - `mbedtls-mem-int-<N>`: keep the builtin management but resize the internal
+///    buffer to `<N>` bytes (both the DTLS and NO_DTLS variants).
+///
+/// These are additive (cargo features are unioned across the dependency graph,
+/// so they cannot be made mutually exclusive). The selection rules:
+///  - `mbedtls-mem-ext` overrides everything — if it is active, MbedTLS goes to
+///    the global allocator and any `mbedtls-mem-int-<N>` is disregarded.
+///  - otherwise, if one or more `mbedtls-mem-int-<N>` are active, the *largest*
+///    size wins.
+pub enum MbedTlsMem {
+    /// Builtin management with OpenThread's own default buffer size (the
+    /// historical behaviour). No `mbedtls-mem-*` feature active.
+    BuiltinDefault,
+    /// Builtin management, internal buffer resized to this many bytes
+    /// (`mbedtls-mem-int-<N>`).
+    BuiltinSized(u32),
+    /// Builtin management OFF — MbedTLS uses the global `calloc`/`free`
+    /// (`mbedtls-mem-ext`).
+    External,
+}
+
+/// The internal-buffer sizes (in bytes) exposed as `mbedtls-mem-int-<N>` cargo
+/// features. Keep in sync with the `mbedtls-mem-int-*` features in `Cargo.toml`
+/// (the build script's guard enforces it).
+pub const MBEDTLS_MEM_INT_SIZES: &[u32] = &[4096, 8192, 16384, 32768, 65536];
+
+/// Resolve the active `mbedtls-mem-*` selection from the `CARGO_FEATURE_*`
+/// environment, applying the additive override rules (see [`MbedTlsMem`]):
+/// `mbedtls-mem-ext` wins over everything; otherwise the largest active
+/// `mbedtls-mem-int-<N>` wins. Must only be called from within the build script.
+pub fn mbedtls_mem() -> MbedTlsMem {
+    if std::env::var_os("CARGO_FEATURE_MBEDTLS_MEM_EXT").is_some() {
+        return MbedTlsMem::External;
+    }
+
+    match MBEDTLS_MEM_INT_SIZES
+        .iter()
+        .copied()
+        .filter(|n| std::env::var_os(format!("CARGO_FEATURE_MBEDTLS_MEM_INT_{n}")).is_some())
+        .max()
+    {
+        Some(n) => MbedTlsMem::BuiltinSized(n),
+        None => MbedTlsMem::BuiltinDefault,
+    }
+}
+
 /// The OpenThread static libraries to link, selected by the device-type
 /// (`ftd`) and radio-location (`rcp`) features. All archives are always *built*;
 /// this picks the subset the firmware actually links so the core-stack archives
@@ -267,6 +329,16 @@ pub fn prebuilt_validity() -> Result<(), String> {
     // compilation and must not reuse it.
     if !use_external_mbedtls() {
         parts.push("-mbedtls-rs-sys (bundled MbedTLS)".to_string());
+    }
+
+    // The prebuilt is built with OpenThread's default MbedTLS memory management
+    // (`MbedTlsMem::BuiltinDefault`). Any `mbedtls-mem-*` override changes the
+    // compiled `.a` (the allocator wiring and/or the internal heap size), so it
+    // must force an on-the-fly rebuild.
+    match mbedtls_mem() {
+        MbedTlsMem::BuiltinDefault => {}
+        MbedTlsMem::BuiltinSized(n) => parts.push(format!("+mbedtls-mem-int-{n}")),
+        MbedTlsMem::External => parts.push("+mbedtls-mem-ext".to_string()),
     }
 
     if parts.is_empty() {

--- a/openthread/Cargo.toml
+++ b/openthread/Cargo.toml
@@ -36,20 +36,26 @@ rcp = ["openthread-sys/rcp"]
 # its own bundled MbedTLS. On by default; omit (with `default-features = false`)
 # to use the bundled MbedTLS and drop the `mbedtls-rs-sys` dependency.
 mbedtls-rs-sys = ["openthread-sys/mbedtls-rs-sys"]
-# MbedTLS memory management (see `openthread-sys`). By default OpenThread rewires
-# MbedTLS to its own small, fixed-size internal heap buffer; these features
-# override that. Additive: `mbedtls-mem-ext` wins, else the largest active
-# `mbedtls-mem-int-<N>`. Only effective with `mbedtls-rs-sys`.
-#   - `mbedtls-mem-ext`: route MbedTLS allocations through the global allocator
-#     (the firmware's `calloc`/`free`) instead of the private fixed buffer — the
-#     fix when the fixed buffer is too small (e.g. Matter + Thread coexistence).
-#   - `mbedtls-mem-int-<N>`: keep the internal buffer but resize it to N bytes.
-mbedtls-mem-ext = ["openthread-sys/mbedtls-mem-ext"]
-mbedtls-mem-int-4096 = ["openthread-sys/mbedtls-mem-int-4096"]
-mbedtls-mem-int-8192 = ["openthread-sys/mbedtls-mem-int-8192"]
-mbedtls-mem-int-16384 = ["openthread-sys/mbedtls-mem-int-16384"]
-mbedtls-mem-int-32768 = ["openthread-sys/mbedtls-mem-int-32768"]
-mbedtls-mem-int-65536 = ["openthread-sys/mbedtls-mem-int-65536"]
+# Heap configuration (see `openthread-sys`). OpenThread keeps one fixed-size
+# internal heap buffer, shared by its own code and (by default) MbedTLS. Three
+# independent axes tune it:
+#   - `heap-ext-ot`: redirect OpenThread's OWN heap to the global allocator
+#     (`HEAP_EXTERNAL_ENABLE`). The consumer must provide `otPlatCAlloc`/
+#     `otPlatFree`, just as it provides `calloc`/`free` for MbedTLS.
+#   - `heap-ext-mbedtls`: redirect MbedTLS to the global `calloc`/`free` instead
+#     of the internal buffer. Only effective with `mbedtls-rs-sys`.
+#   - `heap-int-<N>`: resize the internal buffer to N bytes (largest wins). The
+#     internal buffer may still be used by whichever consumer is not redirected.
+heap-ext-ot = ["openthread-sys/heap-ext-ot"]
+heap-ext-mbedtls = ["openthread-sys/heap-ext-mbedtls"]
+heap-int-4096 = ["openthread-sys/heap-int-4096"]
+heap-int-6144 = ["openthread-sys/heap-int-6144"]
+heap-int-8192 = ["openthread-sys/heap-int-8192"]
+heap-int-12288 = ["openthread-sys/heap-int-12288"]
+heap-int-16384 = ["openthread-sys/heap-int-16384"]
+heap-int-32768 = ["openthread-sys/heap-int-32768"]
+heap-int-49152 = ["openthread-sys/heap-int-49152"]
+heap-int-65536 = ["openthread-sys/heap-int-65536"]
 defmt = ["dep:defmt", "heapless/defmt", "embassy-time/defmt"]
 force-generate-bindings = ["openthread-sys/force-generate-bindings"]
 force-esp-riscv-gcc = ["openthread-sys/force-esp-riscv-gcc"]

--- a/openthread/Cargo.toml
+++ b/openthread/Cargo.toml
@@ -36,6 +36,20 @@ rcp = ["openthread-sys/rcp"]
 # its own bundled MbedTLS. On by default; omit (with `default-features = false`)
 # to use the bundled MbedTLS and drop the `mbedtls-rs-sys` dependency.
 mbedtls-rs-sys = ["openthread-sys/mbedtls-rs-sys"]
+# MbedTLS memory management (see `openthread-sys`). By default OpenThread rewires
+# MbedTLS to its own small, fixed-size internal heap buffer; these features
+# override that. Additive: `mbedtls-mem-ext` wins, else the largest active
+# `mbedtls-mem-int-<N>`. Only effective with `mbedtls-rs-sys`.
+#   - `mbedtls-mem-ext`: route MbedTLS allocations through the global allocator
+#     (the firmware's `calloc`/`free`) instead of the private fixed buffer — the
+#     fix when the fixed buffer is too small (e.g. Matter + Thread coexistence).
+#   - `mbedtls-mem-int-<N>`: keep the internal buffer but resize it to N bytes.
+mbedtls-mem-ext = ["openthread-sys/mbedtls-mem-ext"]
+mbedtls-mem-int-4096 = ["openthread-sys/mbedtls-mem-int-4096"]
+mbedtls-mem-int-8192 = ["openthread-sys/mbedtls-mem-int-8192"]
+mbedtls-mem-int-16384 = ["openthread-sys/mbedtls-mem-int-16384"]
+mbedtls-mem-int-32768 = ["openthread-sys/mbedtls-mem-int-32768"]
+mbedtls-mem-int-65536 = ["openthread-sys/mbedtls-mem-int-65536"]
 defmt = ["dep:defmt", "heapless/defmt", "embassy-time/defmt"]
 force-generate-bindings = ["openthread-sys/force-generate-bindings"]
 force-esp-riscv-gcc = ["openthread-sys/force-esp-riscv-gcc"]


### PR DESCRIPTION
Switching `rs-matter` to the `mbedtls` backend _and_ trying to run the `light_thread_coex` example in `rs-matter-embassy` fails with MbedTLS error 0x0010 (bigint alloc failed) because rs-matter's MbedTLS usage overruns the tiny 2.6KB "heap" that OpenThread assigns to MbedTLS

The features introduced with this PR allow the user to set the mbedtls-specific heap to 4, 8, 16 and so on KB or - alternatively - instruct OpenThread NOT to redirect MbedTLS's heap to its own buffer and rely on the presence of `calloc/free`.