### PR TITLE
Clamp the Config::power value to one supported by the NRF driver

### DIFF
--- a/openthread/src/nrf.rs
+++ b/openthread/src/nrf.rs
@@ -48,7 +48,40 @@ impl<'a> NrfRadio<'a> {
             Cca::CarrierAndEd { ed_threshold } => RadioCca::EnergyDetection { ed_threshold },
             Cca::CarrierOrEd { ed_threshold } => RadioCca::EnergyDetection { ed_threshold },
         });
-        self.driver.set_transmission_power(config.power);
+        self.driver
+            .set_transmission_power(Self::clamp_tx_power(config.power));
+    }
+
+    /// Snap a requested transmit power (in dBm) to a value the nRF radio's
+    /// `set_transmission_power` accepts.
+    ///
+    /// `Config::power` is a cross-platform dBm value.
+    /// The nRF radio however only supports a discrete set of dBm levels with
+    /// a much lower ceiling (+8 dBm on the nRF52840), and `embassy-nrf`'s
+    /// `set_transmission_power` *panics* on any value not in that set. So map the
+    /// request to the highest supported level not exceeding it (clamping to the
+    /// min/max of the supported range), which both avoids the panic and applies
+    /// the closest power the radio can actually produce.
+    fn clamp_tx_power(power: i8) -> i8 {
+        // The dBm levels `embassy-nrf` accepts for the nRF52840, descending.
+        // Other nRF variants support a subset (e.g. the nRF52811 / nRF5340
+        // network core drop the higher positive levels), but these are the ones
+        // this driver targets. Keep in sync with `embassy_nrf`'s
+        // `Radio::set_transmission_power`.
+        //
+        // TODO: This table is nRF52840-specific. If/when this driver targets
+        // other nRF variants (nRF52811, nRF5340 net core, ...), gate it by chip
+        // `cfg` to match `embassy_nrf`'s own per-chip `match` arms (the higher
+        // positive levels are unavailable on some, and the 5340 net core adds
+        // extra negative levels).
+        const SUPPORTED_DBM: [i8; 15] = [8, 7, 6, 5, 4, 3, 2, 0, -4, -8, -12, -16, -20, -30, -40];
+
+        // Highest supported level <= requested power; if the request is below the
+        // minimum, use the minimum.
+        SUPPORTED_DBM
+            .into_iter()
+            .find(|&level| level <= power)
+            .unwrap_or(SUPPORTED_DBM[SUPPORTED_DBM.len() - 1])
     }
 }
 


### PR DESCRIPTION
NRF-driver specific.

Addresses https://github.com/sysgrok/rs-matter-embassy/issues/50

Works by clamping whatever value the user has configured in the driver-agnostic `Config` to what the driver actually supports. The ESP driver clamps automatically, the NRF driver didn't hence the fix.


(I'm not thrilled by the approach in this PR, but in the short/mid term until/if we figure out how to model device-specific power settings into the otherwise device-agnostic `Config`, I guess that'll do.)