### PR TITLE
Support for DNS and DNS-SD

### DIFF
--- a/examples/esp/Cargo.toml
+++ b/examples/esp/Cargo.toml
@@ -51,7 +51,7 @@ critical-section = "1.2"
 rand_core = "0.9"
 static_cell = "2.1"
 
-openthread = { path = "../../openthread", features = ["udp", "srp", "embassy-net-driver-channel", "esp-radio", "isupper", "log"] }
+openthread = { path = "../../openthread", features = ["udp", "srp", "dns-client", "embassy-net-driver-channel", "esp-radio", "isupper", "log"] }
 tinyrlibc = { version = "0.5", default-features = false, features = ["utoa", "strtoul"] }
 
 [[bin]]
@@ -70,4 +70,10 @@ harness = false
 path = "./src/bin/srp.rs"
 name = "srp"
 #required-features=["srp"]
+harness = false
+
+[[bin]]
+path = "./src/bin/dns.rs"
+name = "dns"
+#required-features=["dns-client"]
 harness = false

--- a/examples/esp/src/bin/dns.rs
+++ b/examples/esp/src/bin/dns.rs
@@ -1,0 +1,256 @@
+//! An example for esp32-c6 and esp32-h2, demonstrating the usage of OpenThread's DNS client API.
+//!
+//! The example provisions an MTD device with fixed Thread network settings, waits for the
+//! device to connect, and then - once operational - periodically issues two kinds of DNS
+//! queries through OpenThread's (unicast) DNS client, demonstrating that the same API serves
+//! both *regular DNS* and *DNS-SD*:
+//!
+//! 1. A regular DNS address (AAAA) resolution of `google.com` -> IPv6 address(es).
+//!    This requires the Thread Border Router to have upstream Internet connectivity and a
+//!    usable recursive DNS server configured for the DNS client (see the default-server config
+//!    knobs in OpenThread, or set one explicitly via `DnsQueryConfig`).
+//!
+//! 2. A DNS-SD browse for all `_matter._tcp` service instances registered with the Thread
+//!    network's SRP/DNS-SD server.
+//!
+//!    NOTE: OpenThread's DNS client is a *unicast* resolver that queries the SRP/DNS-SD server
+//!    on the Thread Border Router, which serves the Thread network domain
+//!    `default.service.arpa` - NOT mDNS's `local` domain. So the browse targets
+//!    `_matter._tcp.default.service.arpa`, not `_matter._tcp.local`. (You can register a
+//!    matching service from another peer using the `srp` example.)
+//!
+//! See README.md for instructions on how to configure the other Thread peer (a FTD / Border
+//! Router).
+
+#![no_std]
+#![no_main]
+
+use log::info;
+
+use embassy_executor::Spawner;
+
+use embassy_time::{Duration, Timer};
+
+use esp_hal::rng::Rng;
+use esp_hal::timer::timg::TimerGroup;
+use esp_radio::ieee802154::Ieee802154;
+use {esp_backtrace as _, esp_println as _};
+
+use openthread::esp::EspRadio;
+use openthread::{
+    DnsResponse, OpenThread, OtResources, OtRngCore, OtUdpResources, SimpleRamSettings,
+};
+
+use tinyrlibc as _;
+
+macro_rules! mk_static {
+    ($t:ty) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit();
+        x
+    }};
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write($val);
+        x
+    }};
+}
+
+const UDP_SOCKETS_BUF: usize = 1280;
+const UDP_MAX_SOCKETS: usize = 2;
+
+/// The regular-DNS host name to resolve to an IPv6 address.
+const DNS_HOST_NAME: &str = "google.com";
+
+/// The DNS-SD service type to browse for, in the Thread network domain
+/// (`default.service.arpa`, served by the Border Router's SRP/DNS-SD server).
+const DNSSD_SERVICE_TYPE: &str = "_matter._tcp.default.service.arpa";
+
+const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
+    dataset
+} else {
+    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+};
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) {
+    esp_alloc::heap_allocator!(size: 1024);
+
+    esp_println::logger::init_logger_from_env();
+
+    info!("Starting...");
+
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(
+        timg0.timer0,
+        #[cfg(target_arch = "riscv32")]
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT)
+            .software_interrupt0,
+    );
+
+    // TODO: Use TRNG?
+    let rng = mk_static!(Rng, Rng::new());
+
+    let mut ieee_eui64 = [0; 8];
+    rng.fill_bytes(&mut ieee_eui64);
+
+    let ot_resources = mk_static!(OtResources, OtResources::new());
+    let ot_udp_resources =
+        mk_static!(OtUdpResources<UDP_MAX_SOCKETS, UDP_SOCKETS_BUF>, OtUdpResources::new());
+    let ot_settings_buf = mk_static!([u8; 1024], [0; 1024]);
+
+    let ot_settings = mk_static!(SimpleRamSettings, SimpleRamSettings::new(ot_settings_buf));
+
+    // No SRP resources are needed: this example is a pure DNS *client*. We still
+    // call `srp_autostart()` below (it works without SRP resources) so the DNS
+    // client can auto-discover its server - see the comment there.
+    let ot = OpenThread::new_with_udp(ieee_eui64, rng, ot_settings, ot_resources, ot_udp_resources)
+        .unwrap();
+
+    spawner.spawn(
+        run_ot(
+            ot.clone(),
+            EspRadio::new(Ieee802154::new(peripherals.IEEE802154)),
+        )
+        .unwrap(),
+    );
+
+    info!("Dataset: {THREAD_DATASET}");
+
+    // This example is a pure DNS *client* - it never registers anything over SRP.
+    // We nonetheless enable SRP auto-start because that is the mechanism by which
+    // OpenThread's DNS client auto-discovers the server to query: it adopts the
+    // SRP/DNS-SD server address that SRP auto-start selects from network data
+    // (see `otDnsClientGetDefaultConfig` / OpenThread's `UpdateDefaultConfigAddress`).
+    // Without this, DNS queries would have no default server; you would then have
+    // to pass an explicit server via `DnsQueryConfig::server`.
+    ot.srp_autostart().unwrap();
+
+    ot.set_active_dataset_tlv_hexstr(THREAD_DATASET).unwrap();
+    ot.enable_ipv6(true).unwrap();
+    ot.enable_thread(true).unwrap();
+
+    // Wait until the device is attached (has a unicast, non-link-local address).
+    info!("Waiting for the device to connect to the Thread network...");
+    loop {
+        let mut connected = false;
+        ot.ipv6_addrs(|addr| {
+            if let Some((addr, _prefix)) = addr {
+                if !addr.is_unicast_link_local() && !addr.is_loopback() {
+                    connected = true;
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        if connected {
+            break;
+        }
+
+        ot.wait_changed().await;
+    }
+
+    info!("Connected. Starting DNS queries...");
+
+    loop {
+        // --- 1. Regular DNS: resolve a host name to its IPv6 address(es). ---
+        info!("Resolving `{DNS_HOST_NAME}` (regular DNS, AAAA)...");
+
+        let result = ot
+            .dns_resolve_address(DNS_HOST_NAME, None, |response| {
+                let DnsResponse::Address(response) = response else {
+                    return;
+                };
+
+                let mut index = 0;
+                loop {
+                    match response.address(index) {
+                        Ok(Some((addr, ttl))) => {
+                            info!("  {DNS_HOST_NAME} -> {addr} (ttl {ttl})");
+                            index += 1;
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            info!("  Error reading address {index}: {e:?}");
+                            break;
+                        }
+                    }
+                }
+
+                if index == 0 {
+                    info!("  No addresses returned");
+                }
+            })
+            .await;
+
+        if let Err(e) = result {
+            info!("Address resolution failed: {e:?}");
+        }
+
+        // --- 2. DNS-SD: browse for service instances of a given type. ---
+        info!("Browsing `{DNSSD_SERVICE_TYPE}` (DNS-SD)...");
+
+        let result = ot
+            .dns_browse(DNSSD_SERVICE_TYPE, None, |response| {
+                let DnsResponse::Browse(response) = response else {
+                    return;
+                };
+
+                let mut label_buf = [0u8; 64];
+                let mut host_buf = [0u8; 128];
+                let mut txt_buf = [0u8; 256];
+
+                let mut index = 0;
+                loop {
+                    let label = match response.service_instance(index, &mut label_buf) {
+                        Ok(Some(label)) => label,
+                        Ok(None) => break,
+                        Err(e) => {
+                            info!("  Error reading instance {index}: {e:?}");
+                            break;
+                        }
+                    };
+
+                    info!("  Instance: {label}");
+
+                    match response.service_info(label, &mut host_buf, &mut txt_buf) {
+                        Ok(info) => {
+                            info!(
+                                "    port {}, host {:?}, addr {:?}, txt {} bytes",
+                                info.port,
+                                info.host_name,
+                                info.host_address,
+                                info.txt_data.map(|t| t.len()).unwrap_or(0),
+                            );
+                        }
+                        Err(e) => info!("    (no service info: {e:?})"),
+                    }
+
+                    index += 1;
+                }
+
+                if index == 0 {
+                    info!("  No service instances found");
+                }
+            })
+            .await;
+
+        if let Err(e) = result {
+            info!("Browse failed: {e:?}");
+        }
+
+        Timer::after(Duration::from_secs(10)).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run_ot(ot: OpenThread<'static>, radio: EspRadio<'static>) -> ! {
+    ot.run(radio).await
+}

--- a/examples/nrf/Cargo.toml
+++ b/examples/nrf/Cargo.toml
@@ -45,7 +45,7 @@ critical-section = "1.2"
 rand_core = "0.9"
 static_cell = "2.1"
 
-openthread = { path = "../../openthread", features = ["udp", "srp", "embassy-net-driver-channel", "embassy-nrf", "defmt"] }
+openthread = { path = "../../openthread", features = ["udp", "srp", "dns-client", "embassy-net-driver-channel", "embassy-nrf", "defmt"] }
 tinyrlibc = { version = "0.5", default-features = false, features = ["alloc", "strstr", "strcmp", "isupper", "utoa", "strtoul"] }
 embedded-alloc = "0.7.0"
 
@@ -65,4 +65,10 @@ harness = false
 path = "./src/bin/srp.rs"
 name = "srp"
 #required-features=["srp"]
+harness = false
+
+[[bin]]
+path = "./src/bin/dns.rs"
+name = "dns"
+#required-features=["dns-client"]
 harness = false

--- a/examples/nrf/src/bin/dns.rs
+++ b/examples/nrf/src/bin/dns.rs
@@ -1,0 +1,295 @@
+//! An example for NRF, demonstrating the usage of OpenThread's DNS client API.
+//!
+//! The example provisions an MTD device with fixed Thread network settings, waits for the
+//! device to connect, and then - once operational - periodically issues two kinds of DNS
+//! queries through OpenThread's (unicast) DNS client, demonstrating that the same API serves
+//! both *regular DNS* and *DNS-SD*:
+//!
+//! 1. A regular DNS address (AAAA) resolution of `google.com` -> IPv6 address(es).
+//!    This requires the Thread Border Router to have upstream Internet connectivity and a
+//!    usable recursive DNS server configured for the DNS client (see the default-server config
+//!    knobs in OpenThread, or set one explicitly via `DnsQueryConfig`).
+//!
+//! 2. A DNS-SD browse for all `_matter._tcp` service instances registered with the Thread
+//!    network's SRP/DNS-SD server.
+//!
+//!    NOTE: OpenThread's DNS client is a *unicast* resolver that queries the SRP/DNS-SD server
+//!    on the Thread Border Router, which serves the Thread network domain
+//!    `default.service.arpa` - NOT mDNS's `local` domain. So the browse targets
+//!    `_matter._tcp.default.service.arpa`, not `_matter._tcp.local`. (You can register a
+//!    matching service from another peer using the `srp` example.)
+//!
+//! See README.md for instructions on how to configure the other Thread peer (a FTD / Border
+//! Router).
+
+#![no_std]
+#![no_main]
+
+use defmt::info;
+
+use embedded_alloc::LlffHeap as Heap;
+
+use embassy_executor::InterruptExecutor;
+use embassy_executor::Spawner;
+
+use embassy_nrf::interrupt;
+use embassy_nrf::interrupt::{InterruptExt, Priority};
+use embassy_nrf::mode::Blocking;
+use embassy_nrf::rng::Rng;
+use embassy_nrf::{bind_interrupts, peripherals, radio};
+
+use embassy_time::{Duration, Timer};
+
+use openthread::nrf::{Ieee802154, NrfRadio};
+use openthread::sys::otRadioCaps;
+use openthread::{
+    DnsResponse, EmbassyTimeTimer, OpenThread, OtResources, OtUdpResources, PhyRadioRunner,
+    ProxyRadio, ProxyRadioResources, Radio, SimpleRamSettings,
+};
+
+use panic_rtt_target as _;
+
+use rand_core::RngCore;
+
+use tinyrlibc as _;
+
+macro_rules! mk_static {
+    ($t:ty) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit();
+        x
+    }};
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write($val);
+        x
+    }};
+}
+
+bind_interrupts!(struct Irqs {
+    RADIO => radio::InterruptHandler<peripherals::RADIO>;
+});
+
+#[interrupt]
+unsafe fn EGU0_SWI0() {
+    EXECUTOR_HIGH.on_interrupt()
+}
+
+static EXECUTOR_HIGH: InterruptExecutor = InterruptExecutor::new();
+
+const UDP_SOCKETS_BUF: usize = 1280;
+const UDP_MAX_SOCKETS: usize = 2;
+
+/// The regular-DNS host name to resolve to an IPv6 address.
+const DNS_HOST_NAME: &str = "google.com";
+
+/// The DNS-SD service type to browse for, in the Thread network domain
+/// (`default.service.arpa`, served by the Border Router's SRP/DNS-SD server).
+const DNSSD_SERVICE_TYPE: &str = "_matter._tcp.default.service.arpa";
+
+const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
+    dataset
+} else {
+    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+};
+
+const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
+
+// Only needed for tinyrlibc's alloc functions which won't be called at runtime.
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let mut config = embassy_nrf::config::Config::default();
+    config.hfclk_source = embassy_nrf::config::HfclkSource::ExternalXtal;
+
+    let p = embassy_nrf::init(config);
+
+    rtt_target::rtt_init_defmt!();
+
+    info!("Starting...");
+
+    let rng = mk_static!(Rng<'static, Blocking>, Rng::new_blocking(p.RNG));
+
+    let mut ieee_eui64 = [0; 8];
+    RngCore::fill_bytes(rng, &mut ieee_eui64);
+
+    let ot_resources = mk_static!(OtResources, OtResources::new());
+    let ot_udp_resources =
+        mk_static!(OtUdpResources<UDP_MAX_SOCKETS, UDP_SOCKETS_BUF>, OtUdpResources::new());
+    let ot_settings_buf = mk_static!([u8; 1024], [0; 1024]);
+
+    let ot_settings = mk_static!(SimpleRamSettings, SimpleRamSettings::new(ot_settings_buf));
+
+    // No SRP resources are needed: this example is a pure DNS *client*. We still
+    // call `srp_autostart()` below (it works without SRP resources) so the DNS
+    // client can auto-discover its server - see the comment there.
+    let ot = OpenThread::new_with_udp(ieee_eui64, rng, ot_settings, ot_resources, ot_udp_resources)
+        .unwrap();
+
+    info!("About to spawn OT runner");
+
+    let radio = NrfRadio::new(Ieee802154::new(p.RADIO, Irqs));
+
+    let proxy_radio_resources = mk_static!(ProxyRadioResources, ProxyRadioResources::new());
+    let (proxy_radio, phy_radio_runner) = ProxyRadio::new(proxy_radio_resources);
+
+    // High-priority executor: EGU0_SWI0, priority level 7
+    interrupt::EGU0_SWI0.set_priority(Priority::P7);
+
+    let spawner_high = EXECUTOR_HIGH.start(interrupt::EGU0_SWI0);
+    spawner_high.spawn(run_radio(phy_radio_runner, radio).unwrap());
+
+    info!("Radio created");
+
+    spawner.spawn(run_ot(ot.clone(), proxy_radio).unwrap());
+
+    info!("Dataset: {}", THREAD_DATASET);
+
+    // This example is a pure DNS *client* - it never registers anything over SRP.
+    // We nonetheless enable SRP auto-start because that is the mechanism by which
+    // OpenThread's DNS client auto-discovers the server to query: it adopts the
+    // SRP/DNS-SD server address that SRP auto-start selects from network data
+    // (see `otDnsClientGetDefaultConfig` / OpenThread's `UpdateDefaultConfigAddress`).
+    // Without this, DNS queries would have no default server; you would then have
+    // to pass an explicit server via `DnsQueryConfig::server`.
+    ot.srp_autostart().unwrap();
+
+    ot.set_active_dataset_tlv_hexstr(THREAD_DATASET).unwrap();
+    ot.enable_ipv6(true).unwrap();
+    ot.enable_thread(true).unwrap();
+
+    // Wait until the device is attached (has a mesh-local / non-link-local address).
+    info!("Waiting for the device to connect to the Thread network...");
+    loop {
+        let mut connected = false;
+        ot.ipv6_addrs(|addr| {
+            if let Some((addr, _prefix)) = addr {
+                // A unicast, non-link-local address indicates we are attached.
+                if !addr.is_unicast_link_local() && !addr.is_loopback() {
+                    connected = true;
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        if connected {
+            break;
+        }
+
+        ot.wait_changed().await;
+    }
+
+    info!("Connected. Starting DNS queries...");
+
+    loop {
+        // --- 1. Regular DNS: resolve a host name to its IPv6 address(es). ---
+        info!("Resolving `{}` (regular DNS, AAAA)...", DNS_HOST_NAME);
+
+        let result = ot
+            .dns_resolve_address(DNS_HOST_NAME, None, |response| {
+                let DnsResponse::Address(response) = response else {
+                    return;
+                };
+
+                let mut index = 0;
+                loop {
+                    match response.address(index) {
+                        Ok(Some((addr, ttl))) => {
+                            info!("  {} -> {} (ttl {})", DNS_HOST_NAME, addr, ttl);
+                            index += 1;
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            info!("  Error reading address {}: {:?}", index, e);
+                            break;
+                        }
+                    }
+                }
+
+                if index == 0 {
+                    info!("  No addresses returned");
+                }
+            })
+            .await;
+
+        if let Err(e) = result {
+            info!("Address resolution failed: {:?}", e);
+        }
+
+        // --- 2. DNS-SD: browse for service instances of a given type. ---
+        info!("Browsing `{}` (DNS-SD)...", DNSSD_SERVICE_TYPE);
+
+        let result = ot
+            .dns_browse(DNSSD_SERVICE_TYPE, None, |response| {
+                let DnsResponse::Browse(response) = response else {
+                    return;
+                };
+
+                let mut label_buf = [0u8; 64];
+                let mut host_buf = [0u8; 128];
+                let mut txt_buf = [0u8; 256];
+
+                let mut index = 0;
+                loop {
+                    // The instance label getter needs its own buffer; the service-info
+                    // getter then takes the label (as a `CStr`) plus the host/TXT buffers.
+                    let label = match response.service_instance(index, &mut label_buf) {
+                        Ok(Some(label)) => label,
+                        Ok(None) => break,
+                        Err(e) => {
+                            info!("  Error reading instance {}: {:?}", index, e);
+                            break;
+                        }
+                    };
+
+                    info!("  Instance: {}", label);
+
+                    match response.service_info(label, &mut host_buf, &mut txt_buf) {
+                        Ok(info) => {
+                            info!(
+                                "    port {}, host {:?}, addr {:?}, txt {} bytes",
+                                info.port,
+                                info.host_name,
+                                info.host_address,
+                                info.txt_data.map(|t| t.len()).unwrap_or(0),
+                            );
+                        }
+                        Err(e) => info!("    (no service info: {:?})", e),
+                    }
+
+                    index += 1;
+                }
+
+                if index == 0 {
+                    info!("  No service instances found");
+                }
+            })
+            .await;
+
+        if let Err(e) = result {
+            info!("Browse failed: {:?}", e);
+        }
+
+        Timer::after(Duration::from_secs(10)).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run_ot(ot: OpenThread<'static>, radio: ProxyRadio<'static, NRF_RADIO_CAPS>) -> ! {
+    ot.run(radio).await
+}
+
+#[embassy_executor::task]
+async fn run_radio(mut runner: PhyRadioRunner<'static>, radio: NrfRadio<'static>) -> ! {
+    runner
+        .run(
+            radio,
+            EmbassyTimeTimer, /*TODO: Likely not precise enough*/
+        )
+        .await
+}

--- a/openthread-sys/Cargo.toml
+++ b/openthread-sys/Cargo.toml
@@ -137,6 +137,8 @@ prebuilt = ["matter", "mbedtls-rs-sys"]
 # Barebones profile for Matter: SRP client (service registration), SLAAC
 # (address autoconfig), ECDSA, ping. No provisioning (joiner/commissioner),
 # CoAP, DNS server, TCP, etc. (UDP is core and always available.)
+# (`srp-client` already pulls in `ecdsa`, but it is listed explicitly here too
+# for clarity, since Matter requires ECDSA for operational certificates.)
 matter = ["srp-client", "slaac", "ecdsa", "ping-sender"]
 
 # ---------------------------------------------------------------------------
@@ -153,7 +155,11 @@ coap-block = []        # CoAP block-wise transfer (RFC 7959); implies coap
 coap-observe = []      # CoAP observe (RFC 7641); implies coap
 coaps = ["_ot-dtls"]   # secure CoAP (DTLS) — pulls the DTLS/J-PAKE mbedtls features
 # Service discovery / naming
-srp-client = []
+# The SRP client persists its host key as an ECDSA P-256 keypair
+# (`Crypto::Ecdsa::P256::KeyPair` in `settings.hpp`), so `OT_SRP_CLIENT` does not
+# compile without `OT_ECDSA`. OpenThread does not enforce this coupling itself,
+# so we express it here.
+srp-client = ["ecdsa"]
 srp-server = []
 dns-client = []
 dnssd-server = []

--- a/openthread-sys/gen/include/include.h
+++ b/openthread-sys/gen/include/include.h
@@ -1,19 +1,99 @@
-#include "openthread/instance.h"
-#include "openthread/udp.h"
-#include "openthread/thread.h"
-#include "openthread/tasklet.h"
-#include "openthread/nat64.h"
-#include "openthread/netdata.h"
+// Headers fed to `bindgen` to generate the raw `openthread-sys` bindings.
+//
+// This list is the *binding* surface, NOT the *link* surface: every public
+// OpenThread API header is included here so that Rust bindings exist for it,
+// regardless of which cargo features are enabled. The cargo features (and the
+// `OT_*` CMake knobs they map to, see `gen/features.rs`) only control which
+// implementations are compiled into the static `.a` libraries; a binding for a
+// not-compiled-in feature simply has nothing to link against until its feature
+// is enabled. Declarations are cheap and `--gc-sections` drops the unused ones,
+// so we surface them all rather than hand-maintaining a per-feature subset
+// (which previously left most feature flags with no callable Rust API at all).
+//
+// Keep this in sync with the public headers under `openthread/include/openthread`.
 
+// Core
+#include "openthread/instance.h"
+#include "openthread/error.h"
+#include "openthread/tasklet.h"
+#include "openthread/thread.h"
+#include "openthread/thread_ftd.h"
+#include "openthread/link.h"
+#include "openthread/link_raw.h"
+#include "openthread/message.h"
+#include "openthread/dataset.h"
+#include "openthread/dataset_ftd.h"
+#include "openthread/dataset_updater.h"
+#include "openthread/multi_radio.h"
+#include "openthread/radio_stats.h"
+#include "openthread/network_time.h"
+#include "openthread/verhoeff_checksum.h"
+#include "openthread/heap.h"
+#include "openthread/logging.h"
+#include "openthread/config.h"
+
+// IPv6 / addressing
+#include "openthread/ip6.h"
+#include "openthread/icmp6.h"
+#include "openthread/udp.h"
+#include "openthread/tcp.h"
+#include "openthread/tcp_ext.h"
+#include "openthread/nat64.h"
+
+// Network data / service discovery / naming
+#include "openthread/netdata.h"
+#include "openthread/netdata_publisher.h"
+#include "openthread/server.h"
+#include "openthread/srp_client_buffers.h"
+#include "openthread/srp_client.h"
+#include "openthread/srp_server.h"
+#include "openthread/dns.h"
+#include "openthread/dns_client.h"
+#include "openthread/dnssd_server.h"
+#include "openthread/mdns.h"
+
+// Transport / application protocols
+#include "openthread/coap.h"
+#include "openthread/coap_secure.h"
+#include "openthread/sntp.h"
+
+// Commissioning / security
+#include "openthread/commissioner.h"
+#include "openthread/joiner.h"
+#include "openthread/crypto.h"
+#include "openthread/random_crypto.h"
+#include "openthread/random_noncrypto.h"
+#include "openthread/ble_secure.h"
+#include "openthread/tcat.h"
+#include "openthread/border_agent.h"
+
+// Border router / routing / backbone
+#include "openthread/border_router.h"
+#include "openthread/border_routing.h"
+#include "openthread/backbone_router.h"
+#include "openthread/backbone_router_ftd.h"
+
+// Diagnostics / management
+#include "openthread/ping_sender.h"
+#include "openthread/link_metrics.h"
+#include "openthread/jam_detection.h"
+#include "openthread/child_supervision.h"
+#include "openthread/mesh_diag.h"
+#include "openthread/netdiag.h"
+#include "openthread/history_tracker.h"
+#include "openthread/channel_manager.h"
+#include "openthread/channel_monitor.h"
+
+// Misc
+#include "openthread/trel.h"
+
+// Platform callbacks implemented by this crate
 #include "openthread/platform/alarm-milli.h"
 #include "openthread/platform/radio.h"
 #include "openthread/platform/misc.h"
 #include "openthread/platform/entropy.h"
 #include "openthread/platform/settings.h"
 #include "openthread/platform/logging.h"
-
-#include "openthread/srp_client_buffers.h"
-#include "openthread/srp_client.h"
 
 #ifndef OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 #define OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE 1

--- a/openthread/src/dns.rs
+++ b/openthread/src/dns.rs
@@ -1,0 +1,721 @@
+//! A safe, generic wrapper over OpenThread's DNS client API
+//! (`OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE` / the `dns-client` feature).
+//!
+//! Three query primitives are exposed, mirroring OpenThread 1:1:
+//! - [`OpenThread::dns_browse`] - DNS-SD browse (service instance enumeration).
+//! - [`OpenThread::dns_resolve_service`] /
+//!   [`OpenThread::dns_resolve_service_and_host_address`] - service instance
+//!   resolution (SRV / TXT, optionally followed by host AAAA resolution).
+//! - [`OpenThread::dns_resolve_address`] - host name -> IPv6 address(es).
+//!
+//! Each query is `async` and completes when OpenThread invokes its response
+//! callback (on a response or a time-out). The user passes a closure that is
+//! invoked **once**, synchronously, from within that callback, with a borrowed
+//! response accessor ([`DnsBrowseResponse`], [`DnsServiceResponse`] or
+//! [`DnsAddressResponse`]). The accessors expose OpenThread's index-based getter
+//! functions, reading variable-length data (names, TXT) into caller-supplied
+//! buffers - because the underlying response is only valid for the duration of
+//! the callback and must not be retained.
+//!
+//! This wrapper is intentionally Matter-agnostic: it surfaces the raw DNS-SD
+//! capability so it is reusable for any DNS use case, not only Matter discovery.
+//!
+//! Only one DNS query may be in flight at a time per `OpenThread` instance;
+//! starting another while one is pending returns [`otError`] `BUSY`.
+
+use core::ffi::{c_void, CStr};
+use core::future::poll_fn;
+use core::net::Ipv6Addr;
+
+use crate::sys::{
+    otDnsAddressResponse, otDnsAddressResponseGetAddress, otDnsAddressResponseGetHostName,
+    otDnsBrowseResponse, otDnsBrowseResponseGetHostAddress, otDnsBrowseResponseGetServiceInfo,
+    otDnsBrowseResponseGetServiceInstance, otDnsBrowseResponseGetServiceName, otDnsClientBrowse,
+    otDnsClientResolveAddress, otDnsClientResolveService, otDnsClientResolveServiceAndHostAddress,
+    otDnsQueryConfig, otDnsRecursionFlag, otDnsRecursionFlag_OT_DNS_FLAG_NO_RECURSION,
+    otDnsRecursionFlag_OT_DNS_FLAG_RECURSION_DESIRED, otDnsRecursionFlag_OT_DNS_FLAG_UNSPECIFIED,
+    otDnsServiceInfo, otDnsServiceMode, otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV,
+    otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV_TXT,
+    otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV_TXT_OPTIMIZE,
+    otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV_TXT_SEPARATE,
+    otDnsServiceMode_OT_DNS_SERVICE_MODE_TXT, otDnsServiceMode_OT_DNS_SERVICE_MODE_UNSPECIFIED,
+    otDnsServiceResponse, otDnsServiceResponseGetHostAddress, otDnsServiceResponseGetServiceInfo,
+    otDnsServiceResponseGetServiceName, otError, otError_OT_ERROR_BUSY, otError_OT_ERROR_NONE,
+    otError_OT_ERROR_NOT_FOUND, otInstance, otIp6Address,
+};
+use crate::{ot, to_ot_addr, OpenThread, OtContext, OtError};
+
+use core::net::SocketAddrV6;
+
+/// Which records the DNS client queries during a service resolution.
+///
+/// Mirrors `otDnsServiceMode`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DnsServiceMode {
+    /// Use the default mode from the DNS client's default config.
+    #[default]
+    Unspecified,
+    /// Query for SRV record only.
+    Srv,
+    /// Query for TXT record only.
+    Txt,
+    /// Query for both SRV and TXT records in the same message.
+    SrvTxt,
+    /// Query for SRV and TXT records in separate, parallel messages.
+    SrvTxtSeparate,
+    /// Try SRV and TXT together first, then separately if that fails.
+    SrvTxtOptimize,
+}
+
+impl DnsServiceMode {
+    const fn to_ot(self) -> otDnsServiceMode {
+        match self {
+            Self::Unspecified => otDnsServiceMode_OT_DNS_SERVICE_MODE_UNSPECIFIED,
+            Self::Srv => otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV,
+            Self::Txt => otDnsServiceMode_OT_DNS_SERVICE_MODE_TXT,
+            Self::SrvTxt => otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV_TXT,
+            Self::SrvTxtSeparate => otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV_TXT_SEPARATE,
+            Self::SrvTxtOptimize => otDnsServiceMode_OT_DNS_SERVICE_MODE_SRV_TXT_OPTIMIZE,
+        }
+    }
+}
+
+/// Whether the DNS server is asked to resolve the query recursively.
+///
+/// Mirrors `otDnsRecursionFlag`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DnsRecursion {
+    /// Use the default from the DNS client's default config.
+    #[default]
+    Unspecified,
+    /// Ask the server to resolve recursively.
+    Desired,
+    /// Ask the server not to resolve recursively.
+    None,
+}
+
+impl DnsRecursion {
+    const fn to_ot(self) -> otDnsRecursionFlag {
+        match self {
+            Self::Unspecified => otDnsRecursionFlag_OT_DNS_FLAG_UNSPECIFIED,
+            Self::Desired => otDnsRecursionFlag_OT_DNS_FLAG_RECURSION_DESIRED,
+            Self::None => otDnsRecursionFlag_OT_DNS_FLAG_NO_RECURSION,
+        }
+    }
+}
+
+/// Per-query DNS configuration, mirroring `otDnsQueryConfig`.
+///
+/// Every field is optional: a `None`/`Unspecified`/zero value tells OpenThread
+/// to use the corresponding field from its default config (see
+/// `otDnsClientGetDefaultConfig`). Passing `None` for the whole config to a
+/// query uses the default config for all fields.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+pub struct DnsQueryConfig {
+    /// DNS server to query. `None` uses the default server.
+    pub server: Option<SocketAddrV6>,
+    /// Response wait time in milliseconds. `None`/zero = default.
+    pub response_timeout_ms: Option<u32>,
+    /// Maximum transmit attempts before failing. `None`/zero = default.
+    pub max_tx_attempts: Option<u8>,
+    /// Recursion preference.
+    pub recursion: DnsRecursion,
+    /// Which records to query during service resolution.
+    pub service_mode: DnsServiceMode,
+}
+
+impl DnsQueryConfig {
+    fn to_ot(self) -> otDnsQueryConfig {
+        otDnsQueryConfig {
+            mServerSockAddr: self
+                .server
+                .map(|addr| to_ot_addr(&addr))
+                .unwrap_or_else(zeroed_sock_addr),
+            mResponseTimeout: self.response_timeout_ms.unwrap_or(0),
+            mMaxTxAttempts: self.max_tx_attempts.unwrap_or(0),
+            mRecursionFlag: self.recursion.to_ot(),
+            // NAT64 and transport selection are left at their default
+            // (unspecified = zero); callers needing them can be added later.
+            mNat64Mode: 0,
+            mServiceMode: self.service_mode.to_ot(),
+            mTransportProto: 0,
+        }
+    }
+}
+
+fn zeroed_sock_addr() -> crate::sys::otSockAddr {
+    crate::sys::otSockAddr {
+        mAddress: otIp6Address {
+            mFields: crate::sys::otIp6Address__bindgen_ty_1 { m8: [0; 16] },
+        },
+        mPort: 0,
+    }
+}
+
+/// Information about a discovered DNS service instance (from an SRV/TXT lookup).
+///
+/// Borrows the caller-supplied host-name and TXT buffers that were filled by the
+/// originating getter call.
+#[derive(Debug)]
+pub struct DnsServiceInfo<'a> {
+    /// Service record TTL (seconds).
+    pub ttl: u32,
+    /// Service port (from the SRV record).
+    pub port: u16,
+    /// Service priority (from the SRV record).
+    pub priority: u16,
+    /// Service weight (from the SRV record).
+    pub weight: u16,
+    /// The host name the service resolves to, if requested/available.
+    pub host_name: Option<&'a str>,
+    /// The host's first IPv6 address, if available (all-zero = unavailable).
+    pub host_address: Option<Ipv6Addr>,
+    /// TTL of the host address (seconds).
+    pub host_address_ttl: u32,
+    /// Raw TXT record data, if requested/available.
+    pub txt_data: Option<&'a [u8]>,
+    /// Whether the TXT data did not fit in the supplied buffer and was truncated.
+    pub txt_data_truncated: bool,
+    /// TTL of the TXT data (seconds).
+    pub txt_data_ttl: u32,
+}
+
+/// Build an `otDnsServiceInfo` pointing at the caller's host-name and TXT
+/// scratch buffers, run `getter`, then parse the result into a [`DnsServiceInfo`].
+///
+/// Either buffer may be empty to skip retrieving that piece of info.
+fn read_service_info<'a, F>(
+    host_buf: &'a mut [u8],
+    txt_buf: &'a mut [u8],
+    getter: F,
+) -> Result<DnsServiceInfo<'a>, OtError>
+where
+    F: FnOnce(*mut otDnsServiceInfo) -> otError,
+{
+    let mut info = otDnsServiceInfo {
+        mTtl: 0,
+        mPort: 0,
+        mPriority: 0,
+        mWeight: 0,
+        mHostNameBuffer: if host_buf.is_empty() {
+            core::ptr::null_mut()
+        } else {
+            host_buf.as_mut_ptr() as *mut _
+        },
+        mHostNameBufferSize: host_buf.len() as u16,
+        mHostAddress: otIp6Address {
+            mFields: crate::sys::otIp6Address__bindgen_ty_1 { m8: [0; 16] },
+        },
+        mHostAddressTtl: 0,
+        mTxtData: if txt_buf.is_empty() {
+            core::ptr::null_mut()
+        } else {
+            txt_buf.as_mut_ptr()
+        },
+        mTxtDataSize: txt_buf.len() as u16,
+        mTxtDataTruncated: false,
+        mTxtDataTtl: 0,
+    };
+
+    ot!(getter(&mut info))?;
+
+    let host_name = (!info.mHostNameBuffer.is_null())
+        .then(|| {
+            unsafe { CStr::from_ptr(info.mHostNameBuffer) }
+                .to_str()
+                .ok()
+        })
+        .flatten();
+
+    let host_octets = unsafe { info.mHostAddress.mFields.m8 };
+    let host_address = (host_octets != [0; 16]).then(|| Ipv6Addr::from(host_octets));
+
+    let txt_data = (!info.mTxtData.is_null() && info.mTxtDataSize > 0)
+        .then(|| unsafe { core::slice::from_raw_parts(info.mTxtData, info.mTxtDataSize as usize) });
+
+    Ok(DnsServiceInfo {
+        ttl: info.mTtl,
+        port: info.mPort,
+        priority: info.mPriority,
+        weight: info.mWeight,
+        host_name,
+        host_address,
+        host_address_ttl: info.mHostAddressTtl,
+        txt_data,
+        txt_data_truncated: info.mTxtDataTruncated,
+        txt_data_ttl: info.mTxtDataTtl,
+    })
+}
+
+/// Read a name via an OpenThread `...GetName`/`...GetServiceName` getter into
+/// `buf`, returning it as a `&str`. The getter must null-terminate.
+fn read_name<F>(buf: &mut [u8], getter: F) -> Result<&str, OtError>
+where
+    F: FnOnce(*mut core::ffi::c_char, u16) -> otError,
+{
+    ot!(getter(buf.as_mut_ptr() as *mut _, buf.len() as u16))?;
+
+    let cstr = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) };
+    cstr.to_str()
+        .map_err(|_| OtError::new(crate::sys::otError_OT_ERROR_PARSE))
+}
+
+/// Read an index-based IPv6 address getter (`...GetAddress`/`...GetHostAddress`).
+///
+/// Returns `Ok(Some(addr))` for a present record, `Ok(None)` when the index is
+/// past the end (`OT_ERROR_NOT_FOUND`), or an error otherwise.
+#[allow(non_upper_case_globals)]
+fn read_address<F>(getter: F) -> Result<Option<(Ipv6Addr, u32)>, OtError>
+where
+    F: FnOnce(*mut otIp6Address, *mut u32) -> otError,
+{
+    let mut addr = otIp6Address {
+        mFields: crate::sys::otIp6Address__bindgen_ty_1 { m8: [0; 16] },
+    };
+    let mut ttl: u32 = 0;
+
+    match getter(&mut addr, &mut ttl) {
+        otError_OT_ERROR_NONE => Ok(Some((Ipv6Addr::from(unsafe { addr.mFields.m8 }), ttl))),
+        otError_OT_ERROR_NOT_FOUND => Ok(None),
+        err => Err(OtError::new(err)),
+    }
+}
+
+/// A borrowed accessor over a DNS browse (service instance enumeration) response.
+///
+/// Valid only within the browse callback closure; do not retain it. Service
+/// instances are enumerated by index via [`DnsBrowseResponse::service_instance`].
+pub struct DnsBrowseResponse(*const otDnsBrowseResponse);
+
+impl DnsBrowseResponse {
+    /// The queried service name (e.g. `_service._udp.domain`), into `buf`.
+    pub fn service_name<'a>(&self, buf: &'a mut [u8]) -> Result<&'a str, OtError> {
+        read_name(buf, |p, n| unsafe {
+            otDnsBrowseResponseGetServiceName(self.0, p, n)
+        })
+    }
+
+    /// The service instance label at `index` (just the leading label, not the
+    /// full name), into `buf`. Returns `Ok(None)` once the index is past the end.
+    #[allow(non_upper_case_globals)]
+    pub fn service_instance<'a>(
+        &self,
+        index: u16,
+        buf: &'a mut [u8],
+    ) -> Result<Option<&'a str>, OtError> {
+        match unsafe {
+            otDnsBrowseResponseGetServiceInstance(
+                self.0,
+                index,
+                buf.as_mut_ptr() as *mut _,
+                buf.len() as u8,
+            )
+        } {
+            otError_OT_ERROR_NONE => {
+                let cstr = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) };
+                Ok(Some(cstr.to_str().map_err(|_| {
+                    OtError::new(crate::sys::otError_OT_ERROR_PARSE)
+                })?))
+            }
+            otError_OT_ERROR_NOT_FOUND => Ok(None),
+            err => Err(OtError::new(err)),
+        }
+    }
+
+    /// Service info (SRV/TXT/AAAA, when present in the response) for the instance
+    /// labelled `instance_label` (as returned by
+    /// [`DnsBrowseResponse::service_instance`]). `host_buf`/`txt_buf` receive the
+    /// host name and TXT data; pass an empty slice to skip either.
+    pub fn service_info<'a>(
+        &self,
+        instance_label: &str,
+        host_buf: &'a mut [u8],
+        txt_buf: &'a mut [u8],
+    ) -> Result<DnsServiceInfo<'a>, OtError> {
+        let label = CName::new(instance_label)?;
+        read_service_info(host_buf, txt_buf, |info| unsafe {
+            otDnsBrowseResponseGetServiceInfo(self.0, label.as_ptr(), info)
+        })
+    }
+
+    /// The `index`-th IPv6 address advertised for `host_name` in the response.
+    /// Returns `Ok(None)` once the index is past the end.
+    pub fn host_address(
+        &self,
+        host_name: &str,
+        index: u16,
+    ) -> Result<Option<(Ipv6Addr, u32)>, OtError> {
+        let host = CName::new(host_name)?;
+        read_address(|addr, ttl| unsafe {
+            otDnsBrowseResponseGetHostAddress(self.0, host.as_ptr(), index, addr, ttl)
+        })
+    }
+}
+
+/// A borrowed accessor over a DNS service instance resolution response.
+///
+/// Valid only within the resolve-service callback closure; do not retain it.
+pub struct DnsServiceResponse(*const otDnsServiceResponse);
+
+impl DnsServiceResponse {
+    /// The resolved service instance name: the leading label into `label_buf`
+    /// and the rest of the name into `name_buf` (pass an empty `name_buf` to
+    /// skip the latter). Returns the label.
+    pub fn service_name<'a>(
+        &self,
+        label_buf: &'a mut [u8],
+        name_buf: &mut [u8],
+    ) -> Result<&'a str, OtError> {
+        let label_ptr = label_buf.as_mut_ptr() as *mut core::ffi::c_char;
+        let label_cap = label_buf.len() as u8;
+        let (name_ptr, name_cap) = if name_buf.is_empty() {
+            (core::ptr::null_mut(), 0)
+        } else {
+            (
+                name_buf.as_mut_ptr() as *mut core::ffi::c_char,
+                name_buf.len() as u16,
+            )
+        };
+
+        ot!(unsafe {
+            otDnsServiceResponseGetServiceName(self.0, label_ptr, label_cap, name_ptr, name_cap)
+        })?;
+
+        let cstr = unsafe { CStr::from_ptr(label_buf.as_ptr() as *const _) };
+        cstr.to_str()
+            .map_err(|_| OtError::new(crate::sys::otError_OT_ERROR_PARSE))
+    }
+
+    /// Service info (SRV/TXT, plus AAAA when provided) from the response.
+    /// `host_buf`/`txt_buf` receive the host name and TXT data; pass an empty
+    /// slice to skip either.
+    pub fn service_info<'a>(
+        &self,
+        host_buf: &'a mut [u8],
+        txt_buf: &'a mut [u8],
+    ) -> Result<DnsServiceInfo<'a>, OtError> {
+        read_service_info(host_buf, txt_buf, |info| unsafe {
+            otDnsServiceResponseGetServiceInfo(self.0, info)
+        })
+    }
+
+    /// The `index`-th IPv6 address advertised for `host_name`. Returns
+    /// `Ok(None)` once the index is past the end.
+    pub fn host_address(
+        &self,
+        host_name: &str,
+        index: u16,
+    ) -> Result<Option<(Ipv6Addr, u32)>, OtError> {
+        let host = CName::new(host_name)?;
+        read_address(|addr, ttl| unsafe {
+            otDnsServiceResponseGetHostAddress(self.0, host.as_ptr(), index, addr, ttl)
+        })
+    }
+}
+
+/// A borrowed accessor over a DNS address (AAAA) resolution response.
+///
+/// Valid only within the resolve-address callback closure; do not retain it.
+pub struct DnsAddressResponse(*const otDnsAddressResponse);
+
+impl DnsAddressResponse {
+    /// The queried host name, into `buf`.
+    pub fn host_name<'a>(&self, buf: &'a mut [u8]) -> Result<&'a str, OtError> {
+        read_name(buf, |p, n| unsafe {
+            otDnsAddressResponseGetHostName(self.0, p, n)
+        })
+    }
+
+    /// The `index`-th resolved IPv6 address. Returns `Ok(None)` once the index
+    /// is past the end.
+    pub fn address(&self, index: u16) -> Result<Option<(Ipv6Addr, u32)>, OtError> {
+        read_address(|addr, ttl| unsafe {
+            otDnsAddressResponseGetAddress(self.0, index, addr, ttl)
+        })
+    }
+}
+
+/// The borrowed response handed to a DNS query closure, tagged by query kind.
+///
+/// A given query only ever yields its matching variant; the closure typically
+/// matches on the one it expects.
+pub enum DnsResponse {
+    /// A browse (service instance enumeration) response.
+    Browse(DnsBrowseResponse),
+    /// A service instance resolution response.
+    Service(DnsServiceResponse),
+    /// An address (AAAA) resolution response.
+    Address(DnsAddressResponse),
+}
+
+impl<'a> OpenThread<'a> {
+    /// Send a DNS-SD browse (service instance enumeration) query for
+    /// `service_name` (e.g. `_service._udp.domain`).
+    ///
+    /// On a response or time-out, `f` is invoked once with
+    /// [`DnsResponse::Browse`]. Returns the DNS transaction result.
+    pub async fn dns_browse<F>(
+        &self,
+        service_name: &str,
+        config: Option<&DnsQueryConfig>,
+        f: F,
+    ) -> Result<(), OtError>
+    where
+        F: FnMut(&DnsResponse),
+    {
+        self.dns_query(config, f, |instance, ctx, ot_config| {
+            let name = CName::new(service_name)?;
+            ot!(unsafe {
+                otDnsClientBrowse(
+                    instance,
+                    name.as_ptr(),
+                    Some(Self::plat_c_dns_browse_callback),
+                    ctx,
+                    ot_config,
+                )
+            })
+        })
+        .await
+    }
+
+    /// Resolve a service instance (`<instance_label>.<service_name>`), querying
+    /// SRV/TXT records per the config's service mode.
+    ///
+    /// Does not perform a separate host address resolution; any host AAAA records
+    /// are only available if the server included them. Use
+    /// [`OpenThread::dns_resolve_service_and_host_address`] to also resolve the
+    /// host address. On a response or time-out, `f` is invoked once with
+    /// [`DnsResponse::Service`].
+    pub async fn dns_resolve_service<F>(
+        &self,
+        instance_label: &str,
+        service_name: &str,
+        config: Option<&DnsQueryConfig>,
+        f: F,
+    ) -> Result<(), OtError>
+    where
+        F: FnMut(&DnsResponse),
+    {
+        self.dns_query(config, f, |instance, ctx, ot_config| {
+            let label = CName::new(instance_label)?;
+            let name = CName::new(service_name)?;
+            ot!(unsafe {
+                otDnsClientResolveService(
+                    instance,
+                    label.as_ptr(),
+                    name.as_ptr(),
+                    Some(Self::plat_c_dns_service_callback),
+                    ctx,
+                    ot_config,
+                )
+            })
+        })
+        .await
+    }
+
+    /// Like [`OpenThread::dns_resolve_service`], but additionally resolves the
+    /// host name discovered from the SRV record (a follow-up AAAA query) when the
+    /// server did not include the host address. The callback fires once both
+    /// resolutions complete. Cannot be used with `DnsServiceMode::Txt`.
+    pub async fn dns_resolve_service_and_host_address<F>(
+        &self,
+        instance_label: &str,
+        service_name: &str,
+        config: Option<&DnsQueryConfig>,
+        f: F,
+    ) -> Result<(), OtError>
+    where
+        F: FnMut(&DnsResponse),
+    {
+        self.dns_query(config, f, |instance, ctx, ot_config| {
+            let label = CName::new(instance_label)?;
+            let name = CName::new(service_name)?;
+            ot!(unsafe {
+                otDnsClientResolveServiceAndHostAddress(
+                    instance,
+                    label.as_ptr(),
+                    name.as_ptr(),
+                    Some(Self::plat_c_dns_service_callback),
+                    ctx,
+                    ot_config,
+                )
+            })
+        })
+        .await
+    }
+
+    /// Resolve a host name to its IPv6 (AAAA) address(es).
+    ///
+    /// On a response or time-out, `f` is invoked once with
+    /// [`DnsResponse::Address`].
+    pub async fn dns_resolve_address<F>(
+        &self,
+        host_name: &str,
+        config: Option<&DnsQueryConfig>,
+        f: F,
+    ) -> Result<(), OtError>
+    where
+        F: FnMut(&DnsResponse),
+    {
+        self.dns_query(config, f, |instance, ctx, ot_config| {
+            let name = CName::new(host_name)?;
+            ot!(unsafe {
+                otDnsClientResolveAddress(
+                    instance,
+                    name.as_ptr(),
+                    Some(Self::plat_c_dns_address_callback),
+                    ctx,
+                    ot_config,
+                )
+            })
+        })
+        .await
+    }
+
+    /// Shared driver for the three DNS query kinds: install the user closure,
+    /// start the query via `start`, await the completion signal, and return the
+    /// transaction error. Errors with `BUSY` if a DNS query is already in flight.
+    async fn dns_query<F, S>(
+        &self,
+        config: Option<&DnsQueryConfig>,
+        mut f: F,
+        start: S,
+    ) -> Result<(), OtError>
+    where
+        F: FnMut(&DnsResponse),
+        S: FnOnce(*mut otInstance, *mut c_void, *const otDnsQueryConfig) -> Result<(), OtError>,
+    {
+        let config_storage;
+
+        {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            if state.ot.dns_callback.is_some() {
+                warn!("Another DNS query in progress");
+                return Err(OtError::new(otError_OT_ERROR_BUSY));
+            }
+
+            let instance = state.ot.instance;
+
+            // Install the (lifetime-erased) user closure. Same pattern and the
+            // same `mem::forget` caveat as `scan` (see `scan.rs`).
+            let f: &mut dyn FnMut(&DnsResponse) = &mut f;
+            state.ot.dns_callback = Some(unsafe {
+                core::mem::transmute::<&mut dyn FnMut(&DnsResponse), &'a mut dyn FnMut(&DnsResponse)>(
+                    f,
+                )
+            });
+
+            config_storage = config.map(|c| c.to_ot());
+            let config_ptr = config_storage
+                .as_ref()
+                .map_or(core::ptr::null(), |c| c as *const _);
+
+            let res = start(instance, instance as *mut _ as *mut c_void, config_ptr);
+
+            if res.is_err() {
+                // Query never started; release the slot.
+                state.ot.dns_callback = None;
+                res?;
+            }
+        }
+
+        let _guard = scopeguard::guard((), |_| {
+            let mut ot = self.activate();
+            ot.state().ot.dns_callback = None;
+        });
+
+        let error = poll_fn(move |cx| self.activate().state().ot.dns_done.poll_wait(cx)).await;
+
+        ot!(error)
+    }
+
+    unsafe extern "C" fn plat_c_dns_browse_callback(
+        error: otError,
+        response: *const otDnsBrowseResponse,
+        context: *mut c_void,
+    ) {
+        Self::dns_dispatch(
+            error,
+            context,
+            DnsResponse::Browse(DnsBrowseResponse(response)),
+        );
+    }
+
+    unsafe extern "C" fn plat_c_dns_service_callback(
+        error: otError,
+        response: *const otDnsServiceResponse,
+        context: *mut c_void,
+    ) {
+        Self::dns_dispatch(
+            error,
+            context,
+            DnsResponse::Service(DnsServiceResponse(response)),
+        );
+    }
+
+    unsafe extern "C" fn plat_c_dns_address_callback(
+        error: otError,
+        response: *const otDnsAddressResponse,
+        context: *mut c_void,
+    ) {
+        Self::dns_dispatch(
+            error,
+            context,
+            DnsResponse::Address(DnsAddressResponse(response)),
+        );
+    }
+
+    /// Common tail for the three DNS response trampolines: invoke the installed
+    /// user closure with the borrowed response, clear the slot, and signal the
+    /// awaiting future with the transaction error.
+    fn dns_dispatch(error: otError, context: *mut c_void, response: DnsResponse) {
+        let instance = context as *mut otInstance;
+
+        let mut ot = OtContext::callback(instance);
+        let state = ot.state();
+
+        if let Some(f) = state.ot.dns_callback.as_mut() {
+            f(&response);
+        }
+
+        state.ot.dns_callback = None;
+        state.ot.dns_done.signal(error);
+    }
+}
+
+/// A stack-allocated, null-terminated copy of a DNS name to hand to the C API.
+///
+/// DNS names are bounded (<= 255 bytes); a generous fixed buffer avoids needing
+/// a caller-provided scratch buffer for the query side.
+struct CName {
+    buf: [u8; Self::CAP],
+    len: usize,
+}
+
+impl CName {
+    const CAP: usize = 256; // 255 max name + NUL
+
+    fn new(name: &str) -> Result<Self, OtError> {
+        if name.len() + 1 > Self::CAP {
+            return Err(OtError::new(crate::sys::otError_OT_ERROR_INVALID_ARGS));
+        }
+
+        let mut buf = [0u8; Self::CAP];
+        buf[..name.len()].copy_from_slice(name.as_bytes());
+        // `buf` is zero-initialized, so it is already NUL-terminated.
+
+        Ok(Self {
+            buf,
+            len: name.len() + 1,
+        })
+    }
+
+    fn as_ptr(&self) -> *const core::ffi::c_char {
+        debug_assert_eq!(self.buf[self.len - 1], 0);
+        self.buf.as_ptr() as *const _
+    }
+}

--- a/openthread/src/dns.rs
+++ b/openthread/src/dns.rs
@@ -22,6 +22,12 @@
 //!
 //! Only one DNS query may be in flight at a time per `OpenThread` instance;
 //! starting another while one is pending returns [`otError`] `BUSY`.
+//!
+//! NOTE: Like [`OpenThread::scan`], the futures returned by these query methods
+//! are currently NOT `core::mem::forget`-safe. They install a lifetime-erased
+//! reference to the user closure in shared state, relying on their `Drop` to
+//! clear it; calling `core::mem::forget` on a pending DNS query future would
+//! leave a dangling callback pointer behind. Do not `mem::forget` them.
 
 use core::ffi::{c_void, CStr};
 use core::future::poll_fn;
@@ -221,12 +227,11 @@ where
 
     ot!(getter(&mut info))?;
 
-    let host_name = (!info.mHostNameBuffer.is_null())
-        .then(|| {
-            unsafe { CStr::from_ptr(info.mHostNameBuffer) }
-                .to_str()
-                .ok()
-        })
+    // The host name (if any) was written into `host_buf`; parse it back within
+    // that slice rather than via `CStr::from_ptr` on the raw pointer, to keep the
+    // read in bounds even if a terminator is somehow missing.
+    let host_name = (!info.mHostNameBuffer.is_null() && !host_buf.is_empty())
+        .then(|| cstr_from_buf(host_buf).ok())
         .flatten();
 
     let host_octets = unsafe { info.mHostAddress.mFields.m8 };
@@ -250,16 +255,32 @@ where
 }
 
 /// Read a name via an OpenThread `...GetName`/`...GetServiceName` getter into
-/// `buf`, returning it as a `&str`. The getter must null-terminate.
+/// `buf`, returning it as a `&str`.
+///
+/// OpenThread null-terminates the name within `buf`, but we parse it back with
+/// the length-bounded [`CStr::from_bytes_until_nul`] rather than `from_ptr` so a
+/// missing terminator yields a parse error instead of reading out of bounds.
 fn read_name<F>(buf: &mut [u8], getter: F) -> Result<&str, OtError>
 where
     F: FnOnce(*mut core::ffi::c_char, u16) -> otError,
 {
+    if buf.is_empty() {
+        return Err(OtError::new(crate::sys::otError_OT_ERROR_INVALID_ARGS));
+    }
+
     ot!(getter(buf.as_mut_ptr() as *mut _, buf.len() as u16))?;
 
-    let cstr = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) };
-    cstr.to_str()
-        .map_err(|_| OtError::new(crate::sys::otError_OT_ERROR_PARSE))
+    cstr_from_buf(buf)
+}
+
+/// Parse a NUL-terminated C string written by OpenThread into one of our
+/// caller-supplied buffers, keeping the read bounded to the buffer (so a missing
+/// terminator is a parse error rather than out-of-bounds UB).
+fn cstr_from_buf(buf: &[u8]) -> Result<&str, OtError> {
+    CStr::from_bytes_until_nul(buf)
+        .ok()
+        .and_then(|cstr| cstr.to_str().ok())
+        .ok_or_else(|| OtError::new(crate::sys::otError_OT_ERROR_PARSE))
 }
 
 /// Read an index-based IPv6 address getter (`...GetAddress`/`...GetHostAddress`).
@@ -305,20 +326,18 @@ impl DnsBrowseResponse {
         index: u16,
         buf: &'a mut [u8],
     ) -> Result<Option<&'a str>, OtError> {
+        if buf.is_empty() {
+            return Err(OtError::new(crate::sys::otError_OT_ERROR_INVALID_ARGS));
+        }
+
+        // The OT getter takes a `uint8_t` capacity; a service instance label is
+        // at most 63 bytes, so clamp rather than silently truncate a large `buf`.
+        let cap = buf.len().min(u8::MAX as usize) as u8;
+
         match unsafe {
-            otDnsBrowseResponseGetServiceInstance(
-                self.0,
-                index,
-                buf.as_mut_ptr() as *mut _,
-                buf.len() as u8,
-            )
+            otDnsBrowseResponseGetServiceInstance(self.0, index, buf.as_mut_ptr() as *mut _, cap)
         } {
-            otError_OT_ERROR_NONE => {
-                let cstr = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) };
-                Ok(Some(cstr.to_str().map_err(|_| {
-                    OtError::new(crate::sys::otError_OT_ERROR_PARSE)
-                })?))
-            }
+            otError_OT_ERROR_NONE => Ok(Some(cstr_from_buf(buf)?)),
             otError_OT_ERROR_NOT_FOUND => Ok(None),
             err => Err(OtError::new(err)),
         }
@@ -368,8 +387,14 @@ impl DnsServiceResponse {
         label_buf: &'a mut [u8],
         name_buf: &mut [u8],
     ) -> Result<&'a str, OtError> {
+        if label_buf.is_empty() {
+            return Err(OtError::new(crate::sys::otError_OT_ERROR_INVALID_ARGS));
+        }
+
         let label_ptr = label_buf.as_mut_ptr() as *mut core::ffi::c_char;
-        let label_cap = label_buf.len() as u8;
+        // The OT getter takes a `uint8_t` label capacity; a DNS label is at most
+        // 63 bytes, so clamp rather than silently truncate a large `label_buf`.
+        let label_cap = label_buf.len().min(u8::MAX as usize) as u8;
         let (name_ptr, name_cap) = if name_buf.is_empty() {
             (core::ptr::null_mut(), 0)
         } else {
@@ -383,9 +408,7 @@ impl DnsServiceResponse {
             otDnsServiceResponseGetServiceName(self.0, label_ptr, label_cap, name_ptr, name_cap)
         })?;
 
-        let cstr = unsafe { CStr::from_ptr(label_buf.as_ptr() as *const _) };
-        cstr.to_str()
-            .map_err(|_| OtError::new(crate::sys::otError_OT_ERROR_PARSE))
+        cstr_from_buf(label_buf)
     }
 
     /// Service info (SRV/TXT, plus AAAA when provided) from the response.
@@ -598,6 +621,12 @@ impl<'a> OpenThread<'a> {
                 return Err(OtError::new(otError_OT_ERROR_BUSY));
             }
 
+            // Clear any stale completion left over from a prior query whose future
+            // was dropped after the callback signalled but before `poll_wait`
+            // consumed it - otherwise this query would complete immediately with
+            // the previous transaction's error.
+            state.ot.dns_done.reset();
+
             let instance = state.ot.instance;
 
             // Install the (lifetime-erased) user closure. Same pattern and the
@@ -700,7 +729,9 @@ impl CName {
     const CAP: usize = 256; // 255 max name + NUL
 
     fn new(name: &str) -> Result<Self, OtError> {
-        if name.len() + 1 > Self::CAP {
+        // Reject interior NUL bytes: they would truncate the name at the C
+        // boundary, silently targeting a different name than the caller intended.
+        if name.len() + 1 > Self::CAP || name.as_bytes().contains(&0) {
             return Err(OtError::new(crate::sys::otError_OT_ERROR_INVALID_ARGS));
         }
 

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -2027,7 +2027,12 @@ fn to_sock_addr(addr: &otIp6Address, port: u16, netif: u32) -> SocketAddrV6 {
 }
 
 /// Convert a `SocketAddrV6` to an `otSockAddr`.
-#[cfg(any(feature = "udp", feature = "srp"))]
+///
+/// Always compiled (it only uses unconditionally-available `sys` types) rather
+/// than feature-gated, so any consumer (`udp`, `srp`, `dns-client`, ...) can use
+/// it without the `cfg` needing to enumerate every feature. Mirrors the
+/// always-available `to_sock_addr` sibling above.
+#[allow(unused)]
 fn to_ot_addr(addr: &SocketAddrV6) -> crate::sys::otSockAddr {
     crate::sys::otSockAddr {
         mAddress: otIp6Address {

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -30,6 +30,8 @@ use signal::Signal;
 pub use rand_core::RngCore as OtRngCore;
 
 pub use dataset::*;
+#[cfg(feature = "dns-client")]
+pub use dns::*;
 pub use fmt::Bytes as BytesFmt;
 pub use nat64::*;
 pub use netdata::*;
@@ -46,6 +48,8 @@ pub use udp::*;
 pub(crate) mod fmt;
 
 mod dataset;
+#[cfg(feature = "dns-client")]
+mod dns;
 #[cfg(all(feature = "edge-nal", feature = "udp"))]
 pub mod enal;
 #[cfg(feature = "embassy-net-driver-channel")]
@@ -1139,6 +1143,10 @@ impl OtResources {
             settings,
             scan_callback: None,
             scan_done: Signal::new(),
+            #[cfg(feature = "dns-client")]
+            dns_callback: None,
+            #[cfg(feature = "dns-client")]
+            dns_done: Signal::new(),
             radio_resources,
             dataset_resources,
             instance: core::ptr::null_mut(),
@@ -1863,6 +1871,16 @@ struct OtState<'a> {
     scan_callback: Option<&'a mut dyn FnMut(Option<&ScanResult>)>,
     /// Indicate that scanning has completed
     scan_done: Signal<()>,
+    /// The callback to invoke from a DNS client browse/resolve response.
+    /// Holds a lifetime-erased reference to the user closure for the duration of
+    /// the in-flight query (cleared when the query completes). See `dns.rs`.
+    #[cfg(feature = "dns-client")]
+    #[allow(clippy::type_complexity)]
+    dns_callback: Option<&'a mut dyn FnMut(&crate::dns::DnsResponse)>,
+    /// Carries the terminal `otError` of an in-flight DNS query back to the
+    /// awaiting future (signaled from the DNS response C callback).
+    #[cfg(feature = "dns-client")]
+    dns_done: Signal<crate::sys::otError>,
     /// Whether to egress IPv6 packets from OpenThread
     /// If not necessary, this should be disabled, because otherwise the signal below
     /// will be filled with a packet that is not consumed, and the packets of OpenThread

--- a/openthread/src/scan.rs
+++ b/openthread/src/scan.rs
@@ -140,6 +140,11 @@ impl<'a> OpenThread<'a> {
                 return Err(OtError::new(otError_OT_ERROR_BUSY));
             }
 
+            // Clear any stale completion left over from a prior scan whose future
+            // was dropped after the callback signalled but before `poll_wait`
+            // consumed it - otherwise this scan would complete immediately.
+            state.ot.scan_done.reset();
+
             {
                 let f: &mut dyn FnMut(Option<&ScanResult>) = &mut f;
 

--- a/openthread/src/srp.rs
+++ b/openthread/src/srp.rs
@@ -686,19 +686,31 @@ impl OpenThread<'_> {
     }
 
     /// Return `true` if the SRP client is in auto-start mode, `false` otherwise.
+    ///
+    /// Note: unlike most SRP APIs, this does not require the `OpenThread` instance
+    /// to have been created with SRP resources (see [`OpenThread::srp_autostart`]).
     pub fn srp_autostart_enabled(&self) -> Result<bool, OtError> {
         let mut ot = self.activate();
         let instance = ot.state().ot.instance;
-        let _ = ot.state().srp()?;
 
         Ok(unsafe { otSrpClientIsAutoStartModeEnabled(instance) })
     }
 
     /// Auto-starts the SRP client.
+    ///
+    /// This only flips the auto-start flag on the underlying OpenThread instance
+    /// and registers the (state-guarded) auto-start callback; it does NOT touch
+    /// the Rust-side SRP state buffers. It therefore does not require the
+    /// `OpenThread` instance to have been created with SRP resources (i.e. via a
+    /// `new_with*_srp` constructor) - a plain `new`/`new_with_udp` instance works.
+    ///
+    /// This matters because enabling SRP auto-start is also what lets OpenThread's
+    /// DNS client auto-discover the server to query (it adopts the SRP/DNS-SD
+    /// server address auto-start selects from network data). A DNS-client-only
+    /// consumer can thus enable server discovery without allocating SRP resources.
     pub fn srp_autostart(&self) -> Result<(), OtError> {
         let mut ot = self.activate();
         let instance = ot.state().ot.instance;
-        let _ = ot.state().srp()?;
 
         unsafe {
             otSrpClientEnableAutoStartMode(


### PR DESCRIPTION
It is necessary for `rs-matter` in that (to oversimplify) 
- (the Responder use case) We need not just to reply with our fabric and Node IDs to peer queries (= the existing SRP client) 
- ... (the Initiator use case) but we also need to be able ourselves to issue such queries so as to figure out the IP address corresponding to the peer with the given fabric and Node IDs

Both DNS-SD and DNS in OpenThread are done via the DNS API.

For now, I've exposed the DNS capabilities as an API similar to `scan`, and therefore, this API is subject to the same "please do not core::mem::forget me" constraints as the Scan API (#25). Once we decide what/if we should do for Scan, this should also be the decision for the DNS API too.

EDIT: Of course the DNS support stands on its own in OpenThread too - look at the DNS examples.

============

As part of this PR I also made sure the Rust bindings in `openthread-sys` are based on ALL OpenThread C headers, so that we never have a missing header (= C API) in the bindings anymore.