### PR TITLE
Avoid panic in RamSettings::get when a stored value is larger than the read buffer

### DIFF
--- a/openthread/src/settings.rs
+++ b/openthread/src/settings.rs
@@ -337,7 +337,7 @@ where
 
         if let Some(setting) = setting {
             let len = setting.1.len().min(buf.len());
-            buf[..len].copy_from_slice(setting.1);
+            buf[..len].copy_from_slice(&setting.1[..len]);
 
             trace!(
                 "Got key: {}, index: {}, value: {}",


### PR DESCRIPTION
`RamSettings::get` (`openthread/src/settings.rs`) truncates a stored value into
the caller's buffer:

```rust
let len = setting.1.len().min(buf.len());
buf[..len].copy_from_slice(setting.1);
```

`copy_from_slice` panics unless source and destination have equal length. `len`
is clamped to `min(stored_len, buf_len)`, but the source `setting.1` is not, so
whenever the stored value is larger than `buf` (i.e. `len == buf.len() <
setting.1.len()`) the call panics with "source slice length (N) does not match
destination slice length (M)".

The returned `Ok(Some(len))` already reports the truncated length, so truncation
is the intended behaviour — only the copy needs to honour it. Clamp the source:

```rust
buf[..len].copy_from_slice(&setting.1[..len]);
```

Latent robustness fix: it triggers only when a caller passes a buffer smaller
than a stored setting.
