### PR TITLE
esp: fix extended-address byte order for the hardware RX filter

### DIFF
--- a/openthread/src/platform.rs
+++ b/openthread/src/platform.rs
@@ -138,7 +138,7 @@ extern "C" fn otPlatRadioGetPromiscuous(instance: *const otInstance) -> bool {
 
 #[no_mangle]
 extern "C" fn otPlatRadioSetExtendedAddress(instance: *const otInstance, address: *const u8) {
-    OtContext::callback(instance).plat_radio_set_extended_address(u64::from_be_bytes(unwrap!(
+    OtContext::callback(instance).plat_radio_set_extended_address(u64::from_le_bytes(unwrap!(
         unsafe { core::slice::from_raw_parts(address, 8) }.try_into()
     )));
 }

--- a/openthread/src/radio.rs
+++ b/openthread/src/radio.rs
@@ -1264,7 +1264,7 @@ mod mac {
 
                     self.pan_id = u16::from_le_bytes(unwrap!(psdu[3..5].try_into()));
                     // See platform.rs, `otPlatRadioSetExtendedAddress` impl
-                    self.dst_ext_addr = u64::from_be_bytes(unwrap!(psdu[5..13].try_into()));
+                    self.dst_ext_addr = u64::from_le_bytes(unwrap!(psdu[5..13].try_into()));
                     self.dst_short_addr = Self::BROADCAST_SHORT_ADDR;
                 }
             }


### PR DESCRIPTION
### Problem
On ESP32 with `esp-radio`, OpenThread never attaches to a Thread network. The node transmits Parent Requests and receives multicast traffic fine, but **receives zero unicast frames** — so it never gets a Parent Response, and MLE attach times out. Because TX and multicast RX work, it looks like a higher-layer problem.

### Root cause
An extended-address byte-order mismatch in the hardware RX address filter:
- `otPlatRadioSetExtendedAddress` delivers the address in **little-endian** order (per `openthread/platform/radio.h`), and `esp-radio` programs its hardware filter with `ext_addr.to_le_bytes()` (esp-rs/esp-hal#5314, "use little-endian byte order for IEEE 802.15.4 extended address").
- But the platform callback decoded it with `from_be_bytes` (and the `MacRadio` frame parser mirrored that), so `Config.ext_addr` / `dst_ext_addr` were byte-reversed vs the on-air little-endian address.

So the filter is loaded byte-reversed; the radio drops every unicast frame addressed to the node. (This was correct before esp-rs/esp-hal#5314, when esp-radio used big-endian; that change flipped esp-radio to the spec-correct little-endian and the decode side wasn't updated to match.)

### Fix
Decode the extended address **little-endian** at the two sites that build the `u64` from the byte slice — `platform.rs` (`otPlatRadioSetExtendedAddress`) and `radio.rs` (the `MacRadio` frame parser). This makes `Config.ext_addr` and the parsed `dst_ext_addr` match the on-air little-endian order and esp-radio's `to_le_bytes` hardware-filter programming.

### Validation
esp32-c6, Matter over Thread: with the fix the device attaches to Thread and operates (commission, attribute reads, reboot auto-recovery); without it, attach never completes. (No nRF hardware here to exercise the `MacRadio` software-filter leg directly, but `radio.rs` is the matching counterpart so the two stay in agreement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
