### PR TITLE
New version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ embassy-nrf = { version = "0.10", default-features = false }
 portable-atomic = { version = "1", default-features = false }
 
 mbedtls-rs-sys = { version = "0.1", default-features = false }
-openthread-sys = { version = "0.1", path = "openthread-sys", default-features = false }
+openthread-sys = { version = "0.2", path = "openthread-sys", default-features = false }
 
 # build dependencies
 anyhow = { version = "1", default-features = false }

--- a/openthread-sys/Cargo.toml
+++ b/openthread-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openthread-sys"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 links = "openthread"
 license = "MIT OR Apache-2.0"

--- a/openthread/Cargo.toml
+++ b/openthread/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openthread"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.84"


### PR DESCRIPTION
Need to raise the sys and main crate version from 0.1.0 to 0.2.0 because (stupid me!) I've reserved the crates' names with "0.1.0" initial version instead of with "0.0.0".