### PR TITLE
The framework dir should be packaged as well

### DIFF
--- a/openthread-sys/Cargo.toml
+++ b/openthread-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openthread-sys"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 links = "openthread"
 license = "MIT OR Apache-2.0"
@@ -18,9 +18,13 @@ exclude = [
     "openthread/script",
     # The vendored mbedtls subtree ships its own tests, programs, docs and IDE
     # project files. We only need the library sources + headers + CMakeLists.
+    # NOTE: do NOT add `.../mbedtls/repo/framework` here. mbedtls's top-level
+    # CMakeLists unconditionally `add_subdirectory(framework)` and FATAL_ERRORs
+    # if it is missing, so the bundled-mbedtls build path — taken whenever the
+    # `mbedtls-rs-sys` feature is OFF requires it. 
+    # It is tiny (a near-empty placeholder CMakeLists), so shipping it costs almost nothing.
     "openthread/third_party/mbedtls/repo/tests",
     "openthread/third_party/mbedtls/repo/programs",
-    "openthread/third_party/mbedtls/repo/framework",
     "openthread/third_party/mbedtls/repo/docs",
     "openthread/third_party/mbedtls/repo/visualc",
     # OpenThread's own `tests/CMakeLists.txt` is unconditionally `add_subdirectory`'d


### PR DESCRIPTION
(It is very small.)

We did not catch this because the `mbedtls-rs-sys` crate uses the ESP-IDF **fork** of MbedTLS (because that fork has some extra hardware hooks), but then in that fork, the framework dir is not required. Unlike in openthread which - when compiled with its own "internal" MbedTLS - uses the stock library.