### PR TITLE
Update several dependencies in the examples; implement an API for fetching buffer usage stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ embassy-time = { version = "0.5", default-features = false }
 embassy-futures = { version = "0.1", default-features = false }
 heapless = { version = "0.9", default-features = false }
 bitflags = { version = "2.5", default-features = false }
-embassy-net-driver-channel = { version = "0.3", default-features = false }
+embassy-net-driver-channel = { version = "0.4", default-features = false }
 esp-radio = { version = "0.18", default-features = false }
 embassy-nrf = { version = "0.10", default-features = false }
 portable-atomic = { version = "1", default-features = false }

--- a/examples/esp/Cargo.toml
+++ b/examples/esp/Cargo.toml
@@ -37,7 +37,7 @@ embassy-executor = "0.10"
 embassy-sync = "0.8"
 embassy-futures = "0.1"
 embassy-time = "0.5"
-embassy-net = { version = "0.7", features = ["proto-ipv6", "medium-ip", "udp", "log"] }
+embassy-net = { version = "0.9", features = ["proto-ipv6", "medium-ip", "udp", "log"] }
 esp-hal = { version = "~1.1", features = ["log-04", "unstable", "exception-handler"] }
 esp-rtos = { version = "0.3", features = ["esp-radio", "embassy"] }
 esp-alloc = { version = "0.10" }
@@ -46,7 +46,7 @@ esp-println = { version = "0.17", features = ["log-04"] }
 esp-radio = { version = "0.18", features = ["unstable", "ieee802154"] }
 esp-bootloader-esp-idf = { version = "0.5", features = ["log-04"] }
 log = "0.4"
-heapless = "0.8" # 0.8 for embassy-net 0.7
+heapless = "0.9"
 critical-section = "1.2"
 rand_core = "0.9"
 static_cell = "2.1"

--- a/examples/esp/src/bin/basic_enet.rs
+++ b/examples/esp/src/bin/basic_enet.rs
@@ -2,8 +2,6 @@
 //!
 //! The example provisions an MTD device with fixed Thread network settings, waits for the device to connect,
 //! and then sends and receives Ipv6 UDP packets over the `IEEE 802.15.4` radio.
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD), using another Esp device.
 
 #![no_std]
 #![no_main]
@@ -54,7 +52,7 @@ const ENET_MAX_SOCKETS: usize = 2;
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();

--- a/examples/esp/src/bin/basic_udp.rs
+++ b/examples/esp/src/bin/basic_udp.rs
@@ -2,8 +2,6 @@
 //!
 //! The example provisions an MTD device with fixed Thread network settings, waits for the device to connect,
 //! and then sends and receives Ipv6 UDP packets over the `IEEE 802.15.4` radio.
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD), using another Esp device.
 
 #![no_std]
 #![no_main]
@@ -49,7 +47,7 @@ const UDP_MAX_SOCKETS: usize = 2;
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();

--- a/examples/esp/src/bin/dns.rs
+++ b/examples/esp/src/bin/dns.rs
@@ -18,9 +18,6 @@
 //!    `default.service.arpa` - NOT mDNS's `local` domain. So the browse targets
 //!    `_matter._tcp.default.service.arpa`, not `_matter._tcp.local`. (You can register a
 //!    matching service from another peer using the `srp` example.)
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD / Border
-//! Router).
 
 #![no_std]
 #![no_main]
@@ -71,7 +68,7 @@ const DNSSD_SERVICE_TYPE: &str = "_matter._tcp.default.service.arpa";
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();

--- a/examples/esp/src/bin/srp.rs
+++ b/examples/esp/src/bin/srp.rs
@@ -5,8 +5,6 @@
 //!
 //! The example also registers the MTD device under the hostname `srp-example` and should thus be pingable as `srp-example.local`
 //! from your Wifi/Ethernet network, as long as you are running the other thread peer as a Thread Border Router (see below).
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD), using another Esp device.
 
 #![no_std]
 #![no_main]
@@ -57,7 +55,7 @@ const SRP_MAX_SERVICES: usize = 2;
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();

--- a/examples/nrf/Cargo.toml
+++ b/examples/nrf/Cargo.toml
@@ -37,10 +37,10 @@ embassy-executor = { version = "0.10", features = ["platform-cortex-m", "executo
 embassy-sync = { version = "0.8", features = ["defmt"] }
 embassy-futures = "0.1"
 embassy-time = { version = "0.5", features = ["defmt"] }
-embassy-net = { version = "0.7", features = ["defmt", "proto-ipv6", "medium-ip", "udp"] }
+embassy-net = { version = "0.9", features = ["defmt", "proto-ipv6", "medium-ip", "udp"] }
 embassy-nrf = { version = "0.10", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 defmt = "0.3"
-heapless = "0.8" # 0.8 for embassy-net 0.7
+heapless = "0.9"
 critical-section = "1.2"
 rand_core = "0.9"
 static_cell = "2.1"

--- a/examples/nrf/src/bin/basic_enet.rs
+++ b/examples/nrf/src/bin/basic_enet.rs
@@ -2,8 +2,6 @@
 //!
 //! The example provisions an MTD device with fixed Thread network settings, waits for the device to connect,
 //! and then sends and receives Ipv6 UDP packets over the `IEEE 802.15.4` radio.
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD), using another Esp device.
 
 #![no_std]
 #![no_main]
@@ -77,7 +75,7 @@ const ENET_MAX_SOCKETS: usize = 2;
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();
@@ -127,7 +125,7 @@ async fn main(spawner: Spawner) {
     let proxy_radio_resources = mk_static!(ProxyRadioResources, ProxyRadioResources::new());
     let (proxy_radio, phy_radio_runner) = ProxyRadio::new(proxy_radio_resources);
 
-    // High-priority executor: EGU1_SWI0, priority level 7
+    // High-priority executor: EGU0_SWI0, priority level 7
     interrupt::EGU0_SWI0.set_priority(Priority::P7);
 
     let spawner_high = EXECUTOR_HIGH.start(interrupt::EGU0_SWI0);

--- a/examples/nrf/src/bin/basic_udp.rs
+++ b/examples/nrf/src/bin/basic_udp.rs
@@ -2,8 +2,6 @@
 //!
 //! The example provisions an MTD device with fixed Thread network settings, waits for the device to connect,
 //! and then sends and receives Ipv6 UDP packets over the `IEEE 802.15.4` radio.
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD), using an Esp device.
 
 #![no_std]
 #![no_main]
@@ -70,7 +68,7 @@ const UDP_MAX_SOCKETS: usize = 2;
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();

--- a/examples/nrf/src/bin/dns.rs
+++ b/examples/nrf/src/bin/dns.rs
@@ -18,9 +18,6 @@
 //!    `default.service.arpa` - NOT mDNS's `local` domain. So the browse targets
 //!    `_matter._tcp.default.service.arpa`, not `_matter._tcp.local`. (You can register a
 //!    matching service from another peer using the `srp` example.)
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD / Border
-//! Router).
 
 #![no_std]
 #![no_main]
@@ -92,7 +89,7 @@ const DNSSD_SERVICE_TYPE: &str = "_matter._tcp.default.service.arpa";
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();

--- a/examples/nrf/src/bin/srp.rs
+++ b/examples/nrf/src/bin/srp.rs
@@ -5,8 +5,6 @@
 //!
 //! The example also registers the MTD device under the hostname `srp-example` and should thus be pingable as `srp-example.local`
 //! from your Wifi/Ethernet network, as long as you are running the other thread peer as a Thread Border Router (see below).
-//!
-//! See README.md for instructions on how to configure the other Thread peer (a FTD), using another Esp device.
 
 #![no_std]
 #![no_main]
@@ -77,7 +75,7 @@ const SRP_MAX_SERVICES: usize = 2;
 const THREAD_DATASET: &str = if let Some(dataset) = option_env!("THREAD_DATASET") {
     dataset
 } else {
-    "0e080000000000010000000300000b35060004001fffe002083a90e3a319a904940708fd1fa298dbd1e3290510fe0458f7db96354eaa6041b880ea9c0f030f4f70656e5468726561642d35386431010258d10410888f813c61972446ab616ee3c556a5910c0402a0f7f8"
+    "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0"
 };
 
 const NRF_RADIO_CAPS: otRadioCaps = NrfRadio::CAPS.bits();

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -71,7 +71,7 @@ mod srp;
 mod udp;
 
 use sys::{
-    otChangedFlags, otDeviceRole, otDeviceRole_OT_DEVICE_ROLE_CHILD,
+    otBufferInfo, otChangedFlags, otDeviceRole, otDeviceRole_OT_DEVICE_ROLE_CHILD,
     otDeviceRole_OT_DEVICE_ROLE_DETACHED, otDeviceRole_OT_DEVICE_ROLE_DISABLED,
     otDeviceRole_OT_DEVICE_ROLE_LEADER, otDeviceRole_OT_DEVICE_ROLE_ROUTER, otError,
     otError_OT_ERROR_ABORT, otError_OT_ERROR_CHANNEL_ACCESS_FAILURE, otError_OT_ERROR_DROP,
@@ -79,11 +79,11 @@ use sys::{
     otError_OT_ERROR_NO_BUFS, otInstance, otInstanceFinalize, otInstanceInitSingle, otIp6Address,
     otIp6GetUnicastAddresses, otIp6IsEnabled, otIp6NewMessageFromBuffer, otIp6Send,
     otIp6SetEnabled, otIp6SetReceiveCallback, otLinkModeConfig, otMessage, otMessageFree,
-    otMessagePriority_OT_MESSAGE_PRIORITY_NORMAL, otMessageRead, otMessageSettings,
-    otOperationalDataset, otOperationalDatasetTlvs, otPlatAlarmMilliFired, otPlatRadioReceiveDone,
-    otPlatRadioTxDone, otPlatRadioTxStarted, otRadioCaps, otRadioFrame, otSetStateChangedCallback,
-    otTaskletsProcess, otThreadGetDeviceRole, otThreadGetExtendedPanId, otThreadSetEnabled,
-    otThreadSetLinkMode, OT_CHANGED_THREAD_ROLE, OT_RADIO_CAPS_ACK_TIMEOUT,
+    otMessageGetBufferInfo, otMessagePriority_OT_MESSAGE_PRIORITY_NORMAL, otMessageRead,
+    otMessageSettings, otOperationalDataset, otOperationalDatasetTlvs, otPlatAlarmMilliFired,
+    otPlatRadioReceiveDone, otPlatRadioTxDone, otPlatRadioTxStarted, otRadioCaps, otRadioFrame,
+    otSetStateChangedCallback, otTaskletsProcess, otThreadGetDeviceRole, otThreadGetExtendedPanId,
+    otThreadSetEnabled, otThreadSetLinkMode, OT_CHANGED_THREAD_ROLE, OT_RADIO_CAPS_ACK_TIMEOUT,
     OT_RADIO_FRAME_MAX_SIZE,
 };
 
@@ -401,6 +401,31 @@ impl<'a> OpenThread<'a> {
             role: device_role,
             ext_pan_id: ext_pan_id.map(|id| u64::from_be_bytes(id.m8)),
             ip6_enabled: unsafe { otIp6IsEnabled(state.ot.instance) },
+        }
+    }
+
+    /// Return statistics of the OpenThread message-buffer pool
+    /// (`otMessageGetBufferInfo`).
+    ///
+    /// The pool is fixed-size. When `free` reaches 0 the stack can no longer
+    /// allocate buffers for incoming or outgoing messages, which surfaces as
+    /// silent congestion — forwarded packets are dropped and the device can
+    /// appear unreachable without any role change. The `reassembly_*` counters
+    /// reflect the 6LoWPAN reassembly queue: incomplete datagrams awaiting
+    /// missing fragments, which pin buffers until they time out.
+    pub fn buffer_info(&self) -> BufferInfo {
+        let mut ot = self.activate();
+        let state = ot.state();
+
+        let mut info: otBufferInfo = unsafe { core::mem::zeroed() };
+        unsafe { otMessageGetBufferInfo(state.ot.instance, &mut info) };
+
+        BufferInfo {
+            total: info.mTotalBuffers,
+            free: info.mFreeBuffers,
+            max_used: info.mMaxUsedBuffers,
+            reassembly_messages: info.m6loReassemblyQueue.mNumMessages,
+            reassembly_buffers: info.m6loReassemblyQueue.mNumBuffers,
         }
     }
 
@@ -1181,6 +1206,23 @@ pub struct NetStatus {
     pub ext_pan_id: Option<u64>,
     /// Whether the IPv6 interface is enabled.
     pub ip6_enabled: bool,
+}
+
+/// Statistics of the OpenThread message-buffer pool (`otMessageGetBufferInfo`).
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct BufferInfo {
+    /// Total number of buffers in the message pool (`0xffff` if unknown).
+    pub total: u16,
+    /// Number of currently free buffers (`0xffff` if unknown).
+    pub free: u16,
+    /// High-water mark of buffers used at once since stack init.
+    pub max_used: u16,
+    /// Messages currently held in the 6LoWPAN reassembly queue (incomplete
+    /// datagrams awaiting missing fragments).
+    pub reassembly_messages: u16,
+    /// Buffers currently held by the 6LoWPAN reassembly queue.
+    pub reassembly_buffers: u16,
 }
 
 /// The device role in the OpenThread network.


### PR DESCRIPTION
Subject says it all.

Buffer usage stats turned very useful for diagnosing driver issues and we need these anyway (and more) for a proper implementation of the rs-matter Thread Diagnostics cluster.

(Also - in the examples, I've touched the "sample" dataset as well (to my latest one :-) ) though of course users will have to provide their own via an env var.)