### PR TITLE
Keep looping forever in receive, if rx_on_idle is active

### DIFF
--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -970,7 +970,7 @@ impl<'a> OpenThread<'a> {
                             Either::Second(result) => {
                                 let mut ot = self.activate();
 
-                                {
+                                let rx_when_idle = {
                                     let state = ot.state();
 
                                     match result {
@@ -1014,9 +1014,26 @@ impl<'a> OpenThread<'a> {
                                             }
                                         }
                                     }
-                                }
+
+                                    state.ot.radio_conf.rx_when_idle
+                                };
 
                                 ot.process_tasklets();
+
+                                // With rx-on-when-idle, OpenThread keeps the radio in
+                                // continuous receive and does NOT re-issue an explicit
+                                // `Rx` command for each frame — it expects a stream of
+                                // `otPlatRadioReceiveDone` callbacks. So keep draining by
+                                // looping straight back into `receive()` (still
+                                // preemptible by a pending Tx via the `new_cmd` arm of
+                                // the select above), rather than breaking out to wait for
+                                // the next radio command. Without this, after delivering
+                                // one frame we park on `radio_cmd().await` for an `Rx`
+                                // command that never comes; a radio with an internal RX
+                                // queue then fills it and goes deaf under sustained load.
+                                if rx_when_idle {
+                                    continue;
+                                }
 
                                 break;
                             }


### PR DESCRIPTION
This is probably the most important fix recently w.r.t. stability and throughput of `openthread`:
https://github.com/esp-rs/openthread/pull/91#issuecomment-4833391666

Rather than experiencing a complete meltdown under a heavy to very heavy load, the stack now drops frames linearly to the load heaviness, and recovers instantly the moment the load goes down.

(Tested with a lot of ping sessions, of various ping packet size, frequency and session duration.)
