### PR TITLE
Tier-2 work

### DIFF
--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -15,6 +15,11 @@ default = []
 # Regenerate the OpenThread bindings on the fly (needed until the committed
 # host-target bindings match the active feature set).
 force-generate-bindings = ["openthread/force-generate-bindings"]
+# FTD (router-capable) device; needed by the `form` example (a network is
+# formed by its first router, the Leader).
+ftd = ["openthread/ftd"]
+# Thread-native (MeshCoP) commissioning; needed by the `joiner` example.
+joiner = ["openthread/joiner"]
 
 [dependencies]
 embassy-executor = { version = "0.10", features = ["platform-std", "executor-thread"] }
@@ -48,3 +53,17 @@ name = "srp"
 [[bin]]
 path = "./src/bin/dns.rs"
 name = "dns"
+
+[[bin]]
+path = "./src/bin/ping.rs"
+name = "ping"
+
+[[bin]]
+path = "./src/bin/form.rs"
+name = "form"
+required-features = ["ftd"]
+
+[[bin]]
+path = "./src/bin/joiner.rs"
+name = "joiner"
+required-features = ["joiner"]

--- a/examples/std/src/bin/form.rs
+++ b/examples/std/src/bin/form.rs
@@ -1,0 +1,179 @@
+//! Host example driving a remote OpenThread RCP over serial: survey the RF
+//! environment with an **energy scan** and then **form a brand-new Thread
+//! network** on the quietest channel, with this node becoming the Leader.
+//!
+//! Demonstrates:
+//! - [`OpenThread::energy_scan`]: per-channel max-RSSI survey;
+//! - [`OpenThread::create_new_network_dataset`] (`ftd` only): generate an
+//!   Operational Dataset with random security parameters, tweak it (network
+//!   name + the channel picked by the scan) and apply it.
+//!
+//! Needs the `ftd` feature (only a Full Thread Device can become Leader):
+//! `cargo run --features ftd --bin form`
+//!
+//! Set the serial device with `RCP_SERIAL` (default `/dev/ttyACM0`) and the
+//! baud rate with `RCP_BAUD` (default 115200).
+
+use embassy_executor::{Executor, Spawner};
+
+use log::{info, warn};
+
+use openthread::spinel::{
+    SerialPort, SpinelRadio, SpinelRadioResources, UartSpinelTransport, UartTransportResources,
+};
+use openthread::{Channels, DeviceRole, OpenThread, OtResources, SimpleRamSettings};
+
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+
+use static_cell::{ConstStaticCell, StaticCell};
+
+// Linked for its `utoa`/`strtoul` C symbols, which OpenThread's C references.
+use tinyrlibc as _;
+
+const DEFAULT_SERIAL: &str = "/dev/ttyACM0";
+const DEFAULT_BAUD: u32 = 115_200;
+
+/// Energy-scan dwell time per channel, in milliseconds.
+const SCAN_DURATION_MILLIS: u16 = 200;
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| spawner.spawn(main_task(spawner).unwrap()));
+}
+
+#[embassy_executor::task]
+async fn main_task(spawner: Spawner) {
+    let serial_path = std::env::var("RCP_SERIAL").unwrap_or_else(|_| DEFAULT_SERIAL.into());
+    let baud = std::env::var("RCP_BAUD")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_BAUD);
+
+    info!("Starting; opening RCP serial {serial_path} @ {baud} baud");
+
+    static RNG: StaticCell<StdRng> = StaticCell::new();
+    let rng = RNG.init(StdRng::from_os_rng());
+
+    let mut ieee_eui64 = [0u8; 8];
+    rng.fill_bytes(&mut ieee_eui64);
+
+    static OT_RESOURCES: StaticCell<OtResources> = StaticCell::new();
+    static OT_SETTINGS_BUF: StaticCell<[u8; 1024]> = StaticCell::new();
+    static OT_SETTINGS: StaticCell<SimpleRamSettings> = StaticCell::new();
+
+    let ot_resources = OT_RESOURCES.init(OtResources::new());
+    let ot_settings_buf = OT_SETTINGS_BUF.init([0; 1024]);
+    let ot_settings = OT_SETTINGS.init(SimpleRamSettings::new(ot_settings_buf));
+
+    let ot = OpenThread::new(ieee_eui64, rng, ot_settings, ot_resources).unwrap();
+
+    static RADIO_RESOURCES: ConstStaticCell<SpinelRadioResources> =
+        ConstStaticCell::new(SpinelRadioResources::new());
+    static UART_RESOURCES: ConstStaticCell<UartTransportResources> =
+        ConstStaticCell::new(UartTransportResources::new());
+
+    let serial = SerialPort::open(&serial_path, baud).expect("open RCP serial");
+    let radio = SpinelRadio::new(
+        UartSpinelTransport::new(serial, UART_RESOURCES.take()),
+        RADIO_RESOURCES.take(),
+    );
+
+    spawner.spawn(run_ot(ot.clone(), radio).unwrap());
+
+    // Bring the interface up (Thread itself stays disabled while we scan).
+    ot.enable_ipv6(true).unwrap();
+
+    // Survey all channels and pick the quietest one (lowest max RSSI).
+    info!("Energy-scanning all channels ({SCAN_DURATION_MILLIS} ms per channel)...");
+
+    let mut quietest: Option<(u8, i8)> = None;
+    ot.energy_scan(Channels::all(), SCAN_DURATION_MILLIS, |result| {
+        if let Some(result) = result {
+            info!(
+                "  channel {:2}: max RSSI {} dBm",
+                result.channel, result.max_rssi
+            );
+
+            if quietest.is_none_or(|(_, rssi)| result.max_rssi < rssi) {
+                quietest = Some((result.channel, result.max_rssi));
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    // A radio that cannot measure channel energy yields an *empty* scan (see
+    // `Radio::energy_scan`); fall back to the random channel picked by
+    // `create_new_network_dataset` in that case.
+    let channel = quietest.map(|(channel, rssi)| {
+        info!("Quietest channel: {channel} (max RSSI {rssi} dBm)");
+        channel
+    });
+
+    if channel.is_none() {
+        warn!("Energy scan produced no measurements; keeping the random channel");
+    }
+
+    // Form a new network on that channel: random security parameters from
+    // OpenThread, our own network name, the surveyed channel.
+    ot.create_new_network_dataset(|dataset| {
+        let mut dataset = dataset.clone();
+        dataset.network_name = Some("OT-RS-FORM");
+        if let Some(channel) = channel {
+            dataset.channel = Some(channel as u16);
+        }
+
+        info!(
+            "Forming network {:?}, PAN ID 0x{:04x}, channel {:?}",
+            dataset.network_name,
+            dataset.pan_id.unwrap_or(0),
+            dataset.channel,
+        );
+
+        ot.set_active_dataset(&dataset)
+    })
+    .unwrap()
+    .unwrap();
+
+    ot.enable_thread(true).unwrap();
+
+    // Wait to become the Leader of the new network, then report.
+    loop {
+        let status = ot.net_status();
+
+        info!(
+            "Role: {:?}, ext PAN ID: {:x?}",
+            status.role, status.ext_pan_id
+        );
+
+        if matches!(status.role, DeviceRole::Leader) {
+            info!("This node is now the Leader of the newly-formed network");
+
+            ot.ipv6_addrs(|addr| {
+                if let Some((addr, prefix)) = addr {
+                    info!("  addr: {addr}/{prefix}");
+                }
+                Ok(())
+            })
+            .unwrap();
+        }
+
+        ot.wait_changed().await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run_ot(
+    ot: OpenThread<'static>,
+    radio: SpinelRadio<'static, UartSpinelTransport<'static, SerialPort>>,
+) -> ! {
+    ot.run(radio).await
+}

--- a/examples/std/src/bin/joiner.rs
+++ b/examples/std/src/bin/joiner.rs
@@ -1,0 +1,146 @@
+//! Host example driving a remote OpenThread RCP over serial: onboard this
+//! device onto a Thread network using the **Thread-native commissioning
+//! protocol** ([`OpenThread::join`]) — no out-of-band dataset provisioning.
+//!
+//! For the join to succeed, a Commissioner must be active on the target
+//! network and admitting this device. E.g. on an OTBR:
+//!
+//! ```text
+//! ot-ctl commissioner start
+//! ot-ctl commissioner joiner add <this device's EUI-64, printed below> J01NME
+//! ```
+//!
+//! (With no Commissioner around, the joiner performs a real discovery scan
+//! and fails with `NotFound` — still a useful bring-up check.)
+//!
+//! Needs the `joiner` feature: `cargo run --features joiner --bin joiner`
+//!
+//! Set the serial device with `RCP_SERIAL` (default `/dev/ttyACM0`), the baud
+//! rate with `RCP_BAUD` (default 115200), and the pre-shared joiner key with
+//! `PSKD` (default `J01NME`).
+
+use embassy_executor::{Executor, Spawner};
+
+use log::{info, warn};
+
+use openthread::spinel::{
+    SerialPort, SpinelRadio, SpinelRadioResources, UartSpinelTransport, UartTransportResources,
+};
+use openthread::{DeviceRole, OpenThread, OtResources, SimpleRamSettings};
+
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+
+use static_cell::{ConstStaticCell, StaticCell};
+
+// Linked for its `utoa`/`strtoul` C symbols, which OpenThread's C references.
+use tinyrlibc as _;
+
+const DEFAULT_SERIAL: &str = "/dev/ttyACM0";
+const DEFAULT_BAUD: u32 = 115_200;
+const DEFAULT_PSKD: &str = "J01NME";
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| spawner.spawn(main_task(spawner).unwrap()));
+}
+
+#[embassy_executor::task]
+async fn main_task(spawner: Spawner) {
+    let serial_path = std::env::var("RCP_SERIAL").unwrap_or_else(|_| DEFAULT_SERIAL.into());
+    let baud = std::env::var("RCP_BAUD")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_BAUD);
+    let pskd = std::env::var("PSKD").unwrap_or_else(|_| DEFAULT_PSKD.into());
+
+    info!("Starting; opening RCP serial {serial_path} @ {baud} baud");
+
+    static RNG: StaticCell<StdRng> = StaticCell::new();
+    let rng = RNG.init(StdRng::from_os_rng());
+
+    let mut ieee_eui64 = [0u8; 8];
+    rng.fill_bytes(&mut ieee_eui64);
+
+    static OT_RESOURCES: StaticCell<OtResources> = StaticCell::new();
+    static OT_SETTINGS_BUF: StaticCell<[u8; 1024]> = StaticCell::new();
+    static OT_SETTINGS: StaticCell<SimpleRamSettings> = StaticCell::new();
+
+    let ot_resources = OT_RESOURCES.init(OtResources::new());
+    let ot_settings_buf = OT_SETTINGS_BUF.init([0; 1024]);
+    let ot_settings = OT_SETTINGS.init(SimpleRamSettings::new(ot_settings_buf));
+
+    let ot = OpenThread::new(ieee_eui64, rng, ot_settings, ot_resources).unwrap();
+
+    static RADIO_RESOURCES: ConstStaticCell<SpinelRadioResources> =
+        ConstStaticCell::new(SpinelRadioResources::new());
+    static UART_RESOURCES: ConstStaticCell<UartTransportResources> =
+        ConstStaticCell::new(UartTransportResources::new());
+
+    let serial = SerialPort::open(&serial_path, baud).expect("open RCP serial");
+    let radio = SpinelRadio::new(
+        UartSpinelTransport::new(serial, UART_RESOURCES.take()),
+        RADIO_RESOURCES.take(),
+    );
+
+    spawner.spawn(run_ot(ot.clone(), radio).unwrap());
+
+    // The joiner needs the interface up (and Thread disabled).
+    ot.enable_ipv6(true).unwrap();
+
+    info!(
+        "Joining with PSKd {pskd:?}; admit this device on the Commissioner with EUI-64 {:016x}",
+        u64::from_be_bytes(ot.ieee_eui64()),
+    );
+
+    loop {
+        match ot.join(&pskd, None).await {
+            Ok(()) => {
+                info!("Join successful - the network credentials are stored; attaching...");
+                break;
+            }
+            Err(e) => {
+                warn!("Join failed: {e:?}; retrying in 5s");
+                embassy_time::Timer::after(embassy_time::Duration::from_secs(5)).await;
+            }
+        }
+    }
+
+    ot.enable_thread(true).unwrap();
+
+    loop {
+        let status = ot.net_status();
+
+        info!(
+            "Role: {:?}, ext PAN ID: {:x?}",
+            status.role, status.ext_pan_id
+        );
+
+        if !matches!(status.role, DeviceRole::Detached | DeviceRole::Disabled) {
+            ot.ipv6_addrs(|addr| {
+                if let Some((addr, prefix)) = addr {
+                    info!("  addr: {addr}/{prefix}");
+                }
+                Ok(())
+            })
+            .unwrap();
+        }
+
+        ot.wait_changed().await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run_ot(
+    ot: OpenThread<'static>,
+    radio: SpinelRadio<'static, UartSpinelTransport<'static, SerialPort>>,
+) -> ! {
+    ot.run(radio).await
+}

--- a/examples/std/src/bin/ping.rs
+++ b/examples/std/src/bin/ping.rs
@@ -1,0 +1,170 @@
+//! Host example driving a remote OpenThread RCP over serial: attach to a
+//! Thread network and **ping** another mesh node — ICMPv6 Echo from inside
+//! the OpenThread stack ([`OpenThread::ping`]), reporting per-reply
+//! round-trip times and final loss statistics.
+//!
+//! The destination defaults to the network Leader's Anycast Locator (ALOC) —
+//! an address that exists on every attached mesh, so the example works
+//! without knowing any peer address up front. Override it with `PING_DEST`.
+//!
+//! Set the serial device with `RCP_SERIAL` (default `/dev/ttyACM0`), the baud
+//! rate with `RCP_BAUD` (default 115200) and, optionally, the network with
+//! `THREAD_DATASET` (a hex TLV string).
+
+use core::net::Ipv6Addr;
+
+use embassy_executor::{Executor, Spawner};
+use embassy_time::{Duration, Timer};
+
+use log::info;
+
+use openthread::spinel::{
+    SerialPort, SpinelRadio, SpinelRadioResources, UartSpinelTransport, UartTransportResources,
+};
+use openthread::{DeviceRole, OpenThread, OtResources, PingConfig, SimpleRamSettings};
+
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+
+use static_cell::{ConstStaticCell, StaticCell};
+
+// Linked for its `utoa`/`strtoul` C symbols, which OpenThread's C references.
+use tinyrlibc as _;
+
+const DEFAULT_SERIAL: &str = "/dev/ttyACM0";
+const DEFAULT_BAUD: u32 = 115_200;
+
+const THREAD_DATASET: &str = match option_env!("THREAD_DATASET") {
+    Some(dataset) => dataset,
+    None => "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0",
+};
+
+/// Number of echo requests per ping run.
+const PING_COUNT: u16 = 3;
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| spawner.spawn(main_task(spawner).unwrap()));
+}
+
+#[embassy_executor::task]
+async fn main_task(spawner: Spawner) {
+    let serial_path = std::env::var("RCP_SERIAL").unwrap_or_else(|_| DEFAULT_SERIAL.into());
+    let baud = std::env::var("RCP_BAUD")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_BAUD);
+
+    info!("Starting; opening RCP serial {serial_path} @ {baud} baud");
+
+    static RNG: StaticCell<StdRng> = StaticCell::new();
+    let rng = RNG.init(StdRng::from_os_rng());
+
+    let mut ieee_eui64 = [0u8; 8];
+    rng.fill_bytes(&mut ieee_eui64);
+
+    static OT_RESOURCES: StaticCell<OtResources> = StaticCell::new();
+    static OT_SETTINGS_BUF: StaticCell<[u8; 1024]> = StaticCell::new();
+    static OT_SETTINGS: StaticCell<SimpleRamSettings> = StaticCell::new();
+
+    let ot_resources = OT_RESOURCES.init(OtResources::new());
+    let ot_settings_buf = OT_SETTINGS_BUF.init([0; 1024]);
+    let ot_settings = OT_SETTINGS.init(SimpleRamSettings::new(ot_settings_buf));
+
+    let ot = OpenThread::new(ieee_eui64, rng, ot_settings, ot_resources).unwrap();
+
+    static RADIO_RESOURCES: ConstStaticCell<SpinelRadioResources> =
+        ConstStaticCell::new(SpinelRadioResources::new());
+    static UART_RESOURCES: ConstStaticCell<UartTransportResources> =
+        ConstStaticCell::new(UartTransportResources::new());
+
+    let serial = SerialPort::open(&serial_path, baud).expect("open RCP serial");
+    let radio = SpinelRadio::new(
+        UartSpinelTransport::new(serial, UART_RESOURCES.take()),
+        RADIO_RESOURCES.take(),
+    );
+
+    spawner.spawn(run_ot(ot.clone(), radio).unwrap());
+
+    info!("Dataset: {THREAD_DATASET}");
+
+    ot.set_active_dataset_tlv_hexstr(THREAD_DATASET).unwrap();
+    ot.enable_ipv6(true).unwrap();
+    ot.enable_thread(true).unwrap();
+
+    // Wait until attached.
+    loop {
+        let role = ot.device_role();
+        if matches!(
+            role,
+            DeviceRole::Child | DeviceRole::Router | DeviceRole::Leader
+        ) {
+            info!("Attached to the network as {role:?}");
+            break;
+        }
+
+        ot.wait_changed().await;
+    }
+
+    // The destination: `PING_DEST`, or the Leader ALOC (mesh-local prefix +
+    // the well-known Leader anycast IID `0:ff:fe00:fc00`).
+    let dest = std::env::var("PING_DEST")
+        .ok()
+        .and_then(|addr| addr.parse().ok())
+        .unwrap_or_else(|| {
+            let prefix = ot.mesh_local_prefix();
+
+            let mut aloc = [0u8; 16];
+            aloc[..8].copy_from_slice(&prefix);
+            aloc[8..].copy_from_slice(&[0x00, 0x00, 0x00, 0xff, 0xfe, 0x00, 0xfc, 0x00]);
+
+            Ipv6Addr::from(aloc)
+        });
+
+    let mut config = PingConfig::new(dest);
+    config.count = PING_COUNT;
+
+    loop {
+        info!("Pinging {dest} ({PING_COUNT} requests)...");
+
+        let statistics = ot
+            .ping(&config, |reply| {
+                info!(
+                    "  reply from {}: seq={} bytes={} hops={} time={} ms",
+                    reply.sender,
+                    reply.sequence_number,
+                    reply.size,
+                    reply.hop_limit,
+                    reply.round_trip_time_millis,
+                );
+            })
+            .await
+            .unwrap();
+
+        info!(
+            "{} sent, {} received ({} lost), RTT min/max {}/{} ms",
+            statistics.sent_count,
+            statistics.received_count,
+            statistics.sent_count - statistics.received_count,
+            statistics.min_round_trip_time_millis,
+            statistics.max_round_trip_time_millis,
+        );
+
+        Timer::after(Duration::from_secs(5)).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn run_ot(
+    ot: OpenThread<'static>,
+    radio: SpinelRadio<'static, UartSpinelTransport<'static, SerialPort>>,
+) -> ! {
+    ot.run(radio).await
+}

--- a/openthread/CHANGELOG.md
+++ b/openthread/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Address the Tier 2 API gaps:
+  * `OpenThread::energy_scan`: per-channel max-RSSI survey, e.g. for picking the quietest channel before forming a network
+    * `SpinelRadio` performs real scans on the RCP via the spinel `MAC_SCAN` properties (validated on an ESP32-C6 `ot-rcp`); works even when the RCP under-reports the `ENERGY_SCAN` capability
+    * `otPlatRadioGetRssi` now reports "invalid RSSI" instead of a fake -128 dBm, and `otPlatRadioEnergyScan` routes to the radio instead of panicking
+    * NOTE: the `esp`/`nrf` SoC radios yield no measurements for now — their HALs (`esp-radio` 0.18, `embassy-nrf` 0.10) do not expose the hardware energy detector yet
+  * `OpenThread::create_new_network_dataset` (`ftd`): generate the Operational Dataset for a brand-new network with random security parameters
+  * `OpenThread::join` (new `joiner` feature): Thread-native MeshCoP commissioning with a pre-shared joiner key (PSKd)
+  * `OpenThread::ping` (`ping-sender` feature, now part of the default `matter` bundle): ICMPv6 Echo diagnostics with per-reply callback and final statistics
+  * Bugfix: `OperationalDataset::store_raw` wrote the *pending* timestamp into the *active* timestamp field
+  * New std (RCP-over-serial) examples: `ping` (attach + ping the Leader ALOC), `form` (energy scan + form a new network as Leader), `joiner` (Thread-native commissioning)
 * Address all Tier 1 API gaps (#99):
   * `OpenThread::join_multicast` / `leave_multicast`: interface-level IPv6 multicast group subscription (needed e.g. for Matter group messaging); idempotent
   * Sleepy End Device tuning: `poll_period` / `set_poll_period`, `child_timeout` / `set_child_timeout`, and the child-supervision interval / check-timeout getters and setters

--- a/openthread/Cargo.toml
+++ b/openthread/Cargo.toml
@@ -83,7 +83,7 @@ isupper = [] # Provide internal implementation of the `isupper` C fn
 # ---------------------------------------------------------------------------
 
 # Barebones profile for Matter
-matter = ["srp-client", "dns-client", "openthread-sys/matter"]
+matter = ["srp-client", "dns-client", "ping-sender", "openthread-sys/matter"]
 
 # ---------------------------------------------------------------------------
 # OpenThread capability features. Each re-exports the corresponding

--- a/openthread/src/dataset.rs
+++ b/openthread/src/dataset.rs
@@ -2,6 +2,8 @@
 //!
 //! Basically, a way to configure the Thread network settings.
 
+#[cfg(feature = "ftd")]
+use crate::sys::otDatasetCreateNewNetwork;
 use crate::sys::{
     otDatasetGetActive, otDatasetParseTlvs, otDatasetSetActive, otDatasetSetActiveTlvs,
     otDatasetSetPending, otDatasetSetPendingTlvs, otError_OT_ERROR_INVALID_ARGS,
@@ -40,7 +42,68 @@ pub struct OperationalDataset<'a> {
     pub channel_mask: Option<u32>,
 }
 
-impl OperationalDataset<'_> {
+impl<'a> OperationalDataset<'a> {
+    /// Load a dataset from the format the `OpenThread` C library provides.
+    ///
+    /// The inverse of [`Self::store_raw`]: components marked absent load as
+    /// `None`, and the network name borrows from `raw`.
+    ///
+    /// (Currently only consumed by the `ftd`-gated
+    /// [`OpenThread::create_new_network_dataset`], hence the `cfg`.)
+    #[cfg(feature = "ftd")]
+    pub(crate) fn load_raw(raw: &'a otOperationalDataset) -> Self {
+        let components = OperationalDatasetComponents::load_raw(&raw.mComponents);
+
+        Self {
+            active_timestamp: components
+                .active_timestamp_present
+                .then(|| ThreadTimestamp {
+                    seconds: raw.mActiveTimestamp.mSeconds,
+                    ticks: raw.mActiveTimestamp.mTicks,
+                    authoritative: raw.mActiveTimestamp.mAuthoritative,
+                }),
+            pending_timestamp: components
+                .pending_timestamp_present
+                .then(|| ThreadTimestamp {
+                    seconds: raw.mPendingTimestamp.mSeconds,
+                    ticks: raw.mPendingTimestamp.mTicks,
+                    authoritative: raw.mPendingTimestamp.mAuthoritative,
+                }),
+            network_key: components.network_key_present.then(|| raw.mNetworkKey.m8),
+            network_name: components.network_name_present.then(|| {
+                let name = unsafe {
+                    core::slice::from_raw_parts(
+                        raw.mNetworkName.m8.as_ptr() as *const u8,
+                        raw.mNetworkName.m8.len(),
+                    )
+                };
+
+                unwrap!(
+                    unwrap!(
+                        core::ffi::CStr::from_bytes_until_nul(name),
+                        "Not a valid CStr"
+                    )
+                    .to_str(),
+                    "Not a valid UTF-8 string"
+                )
+            }),
+            extended_pan_id: components
+                .extended_pan_id_present
+                .then(|| raw.mExtendedPanId.m8),
+            mesh_local_prefix: components
+                .mesh_local_prefix_present
+                .then(|| raw.mMeshLocalPrefix.m8),
+            delay: components.delay_present.then_some(raw.mDelay),
+            pan_id: components.pan_id_present.then_some(raw.mPanId),
+            channel: components.channel_present.then_some(raw.mChannel),
+            pskc: components.pskc_present.then(|| raw.mPskc.m8),
+            security_policy: components
+                .security_policy_present
+                .then(|| SecurityPolicy::load_raw(&raw.mSecurityPolicy)),
+            channel_mask: components.channel_mask_present.then_some(raw.mChannelMask),
+        }
+    }
+
     /// Store the dataset in the format the `OpenThread` C library expects.
     ///
     /// Arguments:
@@ -79,7 +142,7 @@ impl OperationalDataset<'_> {
         }
 
         if let Some(pending_timestamp) = dataset.pending_timestamp {
-            raw_dataset.mActiveTimestamp = otTimestamp {
+            raw_dataset.mPendingTimestamp = otTimestamp {
                 mSeconds: pending_timestamp.seconds,
                 mTicks: pending_timestamp.ticks,
                 mAuthoritative: pending_timestamp.authoritative,
@@ -387,6 +450,38 @@ impl OpenThread<'_> {
                 .then_some(dataset.mChannelMask),
             components,
         })
+    }
+
+    /// Create the Operational Dataset for a brand-new Thread network
+    /// (`otDatasetCreateNewNetwork`): cryptographically random values for the
+    /// security-sensitive parameters (network key, PSKc, extended PAN ID,
+    /// mesh-local prefix), a random PAN ID and channel, and defaults for the
+    /// rest.
+    ///
+    /// The generated dataset is handed to the `f` closure, which can inspect
+    /// or tweak a copy of it (e.g. set the network name, or pin the channel —
+    /// typically picked with [`OpenThread::energy_scan`]) and apply it via
+    /// [`OpenThread::set_active_dataset`]; calling back into this `OpenThread`
+    /// instance from within the closure is allowed. Forming the network then
+    /// amounts to enabling IPv6 and Thread — this node becomes the Leader.
+    #[cfg(feature = "ftd")]
+    pub fn create_new_network_dataset<F, R>(&self, f: F) -> Result<R, OtError>
+    where
+        F: FnOnce(&OperationalDataset<'_>) -> R,
+    {
+        // A stack local (~250 B) rather than the shared dataset scratch in the
+        // resources, so that the activation can be dropped before `f` runs
+        // (which is what allows `f` to call back into this `OpenThread`).
+        let mut raw: otOperationalDataset = unsafe { core::mem::zeroed() };
+
+        {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            ot!(unsafe { otDatasetCreateNewNetwork(state.ot.instance, &mut raw) })?;
+        }
+
+        Ok(f(&OperationalDataset::load_raw(&raw)))
     }
 
     /// Set a new active dataset in the OpenThread stack.

--- a/openthread/src/joiner.rs
+++ b/openthread/src/joiner.rs
@@ -1,0 +1,114 @@
+//! Joiner API: commission this device onto a Thread network via the Thread
+//! commissioning protocol (MeshCoP), using a pre-shared joiner key (PSKd).
+//!
+//! This is the *Thread-native* onboarding flow: a Commissioner active on the
+//! target network (e.g. a border router's web UI, or `ot-cli`'s `commissioner`
+//! with this device's EUI-64 and PSKd) admits the joiner, which then receives
+//! the network credentials over a DTLS session. It is unrelated to (and not
+//! needed for) Matter commissioning, where the operational dataset is
+//! provisioned out-of-band (e.g. over BLE).
+
+use core::ffi::c_void;
+use core::future::poll_fn;
+
+use crate::sys::{
+    otError, otError_OT_ERROR_INVALID_ARGS, otInstance, otJoinerStart, otJoinerStop,
+    OT_JOINER_MAX_PSKD_LENGTH, OT_PROVISIONING_URL_MAX_SIZE,
+};
+use crate::{ot, OpenThread, OtContext, OtError};
+
+impl OpenThread<'_> {
+    /// Join a Thread network using the Thread commissioning protocol
+    /// (`otJoinerStart`): discover nearby networks with an active Commissioner
+    /// admitting this device, establish the (EC-JPAKE) DTLS session using the
+    /// pre-shared joiner key `pskd`, and receive the network credentials.
+    ///
+    /// On success, the received Active Operational Dataset has been stored in
+    /// the stack; attach to the network by enabling Thread
+    /// ([`OpenThread::enable_thread`]).
+    ///
+    /// Prerequisites: the IPv6 interface must be up
+    /// ([`OpenThread::enable_ipv6`]) and the Thread protocol must be disabled,
+    /// otherwise an `INVALID_STATE` error is reported.
+    ///
+    /// Arguments:
+    /// - `pskd`: the pre-shared joiner key, as printed on the device / its
+    ///   packaging: 6 to 32 uppercase alphanumeric characters excluding
+    ///   `I`, `O`, `Q` and `Z` (validated by OpenThread).
+    /// - `provisioning_url`: an optional provisioning URL (max 64 bytes),
+    ///   advertised to the Commissioner.
+    ///
+    /// Dropping the returned future cancels the join in progress
+    /// (`otJoinerStop`).
+    pub async fn join(&self, pskd: &str, provisioning_url: Option<&str>) -> Result<(), OtError> {
+        // NUL-terminated stack copies of the string arguments
+        // (`otJoinerStart` takes C strings).
+        let mut pskd_buf = [0u8; OT_JOINER_MAX_PSKD_LENGTH as usize + 1];
+        let mut url_buf = [0u8; OT_PROVISIONING_URL_MAX_SIZE as usize + 1];
+
+        if pskd.len() >= pskd_buf.len() {
+            return Err(OtError::new(otError_OT_ERROR_INVALID_ARGS));
+        }
+        pskd_buf[..pskd.len()].copy_from_slice(pskd.as_bytes());
+
+        let url_ptr = if let Some(url) = provisioning_url {
+            if url.len() >= url_buf.len() {
+                return Err(OtError::new(otError_OT_ERROR_INVALID_ARGS));
+            }
+            url_buf[..url.len()].copy_from_slice(url.as_bytes());
+            url_buf.as_ptr().cast()
+        } else {
+            core::ptr::null()
+        };
+
+        {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            // Clear any stale completion left over from a prior join whose
+            // future was dropped after the callback signalled but before the
+            // wait below consumed it.
+            state.ot.join_done.reset();
+
+            ot!(unsafe {
+                otJoinerStart(
+                    state.ot.instance,
+                    pskd_buf.as_ptr().cast(),
+                    url_ptr,
+                    // Vendor name/model/sw-version/data: optional, not sent.
+                    core::ptr::null(),
+                    core::ptr::null(),
+                    core::ptr::null(),
+                    core::ptr::null(),
+                    Some(Self::plat_c_joiner_callback),
+                    state.ot.instance as *mut _,
+                )
+            })?;
+        }
+
+        // Cancel-safety: if this future is dropped before the joiner finishes,
+        // stop the joiner so it does not keep running (and negotiating DTLS)
+        // detached from any consumer. Defused on normal completion below.
+        let guard = scopeguard::guard((), |_| {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            unsafe { otJoinerStop(state.ot.instance) };
+        });
+
+        let res = poll_fn(move |cx| self.activate().state().ot.join_done.poll_wait(cx)).await;
+
+        let _ = scopeguard::ScopeGuard::into_inner(guard);
+
+        ot!(res)
+    }
+
+    unsafe extern "C" fn plat_c_joiner_callback(error: otError, context: *mut c_void) {
+        let instance = context as *mut otInstance;
+
+        let mut ot = OtContext::callback(instance);
+        let state = ot.state();
+
+        state.ot.join_done.signal(error);
+    }
+}

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -36,6 +36,8 @@ pub use fmt::Bytes as BytesFmt;
 pub use nat64::*;
 pub use netdata::*;
 pub use openthread_sys as sys;
+#[cfg(feature = "ping-sender")]
+pub use ping::*;
 pub use radio::*;
 pub use scan::*;
 pub use settings::*;
@@ -51,8 +53,12 @@ mod dataset;
 mod dns;
 #[cfg(feature = "embassy-net-driver-channel")]
 pub mod enet;
+#[cfg(feature = "joiner")]
+mod joiner;
 mod nat64;
 mod netdata;
+#[cfg(feature = "ping-sender")]
+mod ping;
 mod platform;
 mod radio;
 mod scan;
@@ -73,10 +79,11 @@ use sys::{
     otIp6SetEnabled, otIp6SetReceiveCallback, otIpCounters, otLinkModeConfig, otMacCounters,
     otMessage, otMessageFree, otMessageGetBufferInfo, otMessagePriority_OT_MESSAGE_PRIORITY_NORMAL,
     otMessageRead, otMessageSettings, otMleCounters, otOperationalDataset,
-    otOperationalDatasetTlvs, otPlatAlarmMilliFired, otPlatRadioReceiveDone, otPlatRadioTxDone,
-    otPlatRadioTxStarted, otRadioCaps, otRadioFrame, otSetStateChangedCallback, otTaskletsProcess,
-    otThreadGetDeviceRole, otThreadGetExtendedPanId, otThreadSetEnabled, otThreadSetLinkMode,
-    OT_CHANGED_THREAD_ROLE, OT_RADIO_CAPS_ACK_TIMEOUT, OT_RADIO_FRAME_MAX_SIZE,
+    otOperationalDatasetTlvs, otPlatAlarmMilliFired, otPlatRadioEnergyScanDone,
+    otPlatRadioReceiveDone, otPlatRadioTxDone, otPlatRadioTxStarted, otRadioCaps, otRadioFrame,
+    otSetStateChangedCallback, otTaskletsProcess, otThreadGetDeviceRole, otThreadGetExtendedPanId,
+    otThreadSetEnabled, otThreadSetLinkMode, OT_CHANGED_THREAD_ROLE, OT_RADIO_CAPS_ACK_TIMEOUT,
+    OT_RADIO_FRAME_MAX_SIZE, OT_RADIO_RSSI_INVALID,
 };
 
 /// A newtype wrapper over the native OpenThread error type (`otError`).
@@ -1527,6 +1534,68 @@ impl<'a> OpenThread<'a> {
                             }
                         }
                     }
+                    RadioCommand::EnergyScan(_, duration_millis) => {
+                        let channel = cmd.conf().channel;
+
+                        trace!("Energy scan: channel {}, {} ms", channel, duration_millis);
+
+                        let result = {
+                            let mut new_cmd = pin!(radio_cmd());
+                            let mut scan = pin!(radio.energy_scan(channel, duration_millis));
+
+                            embassy_futures::select::select(&mut new_cmd, &mut scan).await
+                        };
+
+                        match result {
+                            Either::First(new_cmd) => {
+                                let mut ot = self.activate();
+
+                                // Report an aborted scan (no valid measurement)
+                                // because we got interrupted by a new command
+                                {
+                                    let state = ot.state();
+                                    unsafe {
+                                        otPlatRadioEnergyScanDone(
+                                            state.ot.instance,
+                                            OT_RADIO_RSSI_INVALID as i8,
+                                        );
+                                    }
+                                }
+
+                                ot.process_tasklets();
+
+                                trace!("Energy scan interrupted by new command: {:?}", new_cmd);
+
+                                cmd = new_cmd;
+                            }
+                            Either::Second(result) => {
+                                let mut ot = self.activate();
+
+                                {
+                                    let state = ot.state();
+
+                                    let max_rssi = match result {
+                                        Ok(max_rssi) => {
+                                            trace!("Energy scan done, max RSSI: {}", max_rssi);
+                                            max_rssi
+                                        }
+                                        Err(err) => {
+                                            warn!("Energy scan failed: {:?}", err);
+                                            OT_RADIO_RSSI_INVALID as i8
+                                        }
+                                    };
+
+                                    unsafe {
+                                        otPlatRadioEnergyScanDone(state.ot.instance, max_rssi);
+                                    }
+                                }
+
+                                ot.process_tasklets();
+
+                                break;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1670,7 +1739,15 @@ impl OtResources {
             settings,
             scan_callback: None,
             scan_done: Signal::new(),
+            energy_scan_callback: None,
+            energy_scan_done: Signal::new(),
             detach_done: Signal::new(),
+            #[cfg(feature = "joiner")]
+            join_done: Signal::new(),
+            #[cfg(feature = "ping-sender")]
+            ping_callback: None,
+            #[cfg(feature = "ping-sender")]
+            ping_done: Signal::new(),
             #[cfg(feature = "dns-client")]
             dns_callback: None,
             #[cfg(feature = "dns-client")]
@@ -1685,7 +1762,24 @@ impl OtResources {
             changes: Signal::new(),
             radio: Signal::new(),
             radio_conf: Config::new(),
-            radio_caps: OT_RADIO_CAPS_ACK_TIMEOUT as otRadioCaps,
+            // The *initial* radio capabilities, before the actual radio is
+            // brought up by `run_radio` and reports its real set.
+            //
+            // NOTE: capabilities which decide whether OpenThread routes an
+            // operation to the platform radio at all MUST be advertised here:
+            // OpenThread's `SubMac` snapshots `otPlatRadioGetCaps` when the
+            // instance is constructed (`sub_mac.cpp`), which in this crate's
+            // architecture happens before a `Radio` instance is even known.
+            //
+            // `ENERGY_SCAN` is therefore always advertised: scan requests are
+            // always routed to the `Radio` trait, whose default `energy_scan`
+            // implementation reports "no measurement" (invalid RSSI) for
+            // radios that cannot measure channel energy — OpenThread then
+            // omits those channels from the scan results. The alternative
+            // (OpenThread's software sampling fallback) cannot work here
+            // anyway, as it needs a synchronous RSSI read (`otPlatRadioGetRssi`)
+            // which is unimplementable on top of an async radio.
+            radio_caps: (OT_RADIO_CAPS_ACK_TIMEOUT | sys::OT_RADIO_CAPS_ENERGY_SCAN) as otRadioCaps,
             pending_rx_when_idle: None,
         }));
 
@@ -2451,7 +2545,15 @@ impl<'a> OtContext<'a> {
     }
 
     fn plat_radio_get_rssi(&mut self) -> i8 {
-        let rssi = -128; // TODO
+        // This is a *synchronous* platform API, but the radio is an async
+        // driver owned by the radio runner task - there is no way to sample it
+        // from here. Report "invalid" (the value the API defines for "no
+        // measurement available"), so consumers - most notably OpenThread's
+        // software energy scan, used when the radio does not advertise
+        // `Capabilities::ENERGY_SCAN` - see honest invalid readings rather
+        // than fake ones. Radios that can measure energy advertise
+        // `ENERGY_SCAN` and serve scans via `Radio::energy_scan` instead.
+        let rssi = OT_RADIO_RSSI_INVALID as i8;
         trace!("Plat radio get RSSI callback, RSSI: {}", rssi);
 
         rssi
@@ -2542,7 +2644,17 @@ impl<'a> OtContext<'a> {
             "Plat radio energy scan callback, channel {}, duration {}",
             channel, duration
         );
-        unreachable!()
+
+        let state = self.state();
+
+        let mut conf = state.ot.radio_conf.clone();
+        conf.channel = channel;
+        state
+            .ot
+            .radio
+            .signal(RadioCommand::EnergyScan(conf, duration));
+
+        Ok(())
     }
 
     fn plat_radio_sleep(&mut self) -> Result<(), OtError> {
@@ -2736,8 +2848,27 @@ struct OtState<'a> {
     scan_callback: Option<&'a mut dyn FnMut(Option<&ScanResult>)>,
     /// Indicate that scanning has completed
     scan_done: Signal<()>,
+    /// The callback to invoke when energy scanning is in progress
+    #[allow(clippy::type_complexity)]
+    energy_scan_callback: Option<&'a mut dyn FnMut(Option<&EnergyScanResult>)>,
+    /// Indicate that energy scanning has completed
+    energy_scan_done: Signal<()>,
     /// Indicate that a graceful detach (`OpenThread::detach_gracefully`) has completed
     detach_done: Signal<()>,
+    /// Carries the terminal `otError` of an in-flight join (`OpenThread::join`)
+    /// back to the awaiting future (signaled from the joiner C callback).
+    #[cfg(feature = "joiner")]
+    join_done: Signal<otError>,
+    /// The callback to invoke for each received ping reply. Holds a
+    /// lifetime-erased reference to the user closure for the duration of the
+    /// in-flight ping (cleared when the ping completes). See `ping.rs`.
+    #[cfg(feature = "ping-sender")]
+    #[allow(clippy::type_complexity)]
+    ping_callback: Option<&'a mut dyn FnMut(&PingReply)>,
+    /// Carries the final statistics of an in-flight ping back to the awaiting
+    /// future (signaled from the ping-statistics C callback).
+    #[cfg(feature = "ping-sender")]
+    ping_done: Signal<PingStatistics>,
     /// The callback to invoke from a DNS client browse/resolve response.
     /// Holds a lifetime-erased reference to the user closure for the duration of
     /// the in-flight query (cleared when the query completes). See `dns.rs`.
@@ -2792,12 +2923,18 @@ enum RadioCommand {
     /// Once the frame is received, it will be copied to `OtData::radio_resources.rcv_frame` and `OtData::radio_resources.rcv_psdu`
     /// and OpenThread C will be signalled by calling `otPlatRadioReceiveDone`
     Rx(Config),
+    /// Perform an energy scan on the channel in the provided configuration, for
+    /// the provided duration in milliseconds
+    ///
+    /// Once the scan completes (or an error occurs) OpenThread C will be
+    /// signalled by calling `otPlatRadioEnergyScanDone`
+    EnergyScan(Config, u16),
 }
 
 impl RadioCommand {
     const fn conf(&self) -> &Config {
         match self {
-            Self::Tx(conf) | Self::Rx(conf) => conf,
+            Self::Tx(conf) | Self::Rx(conf) | Self::EnergyScan(conf, _) => conf,
         }
     }
 }

--- a/openthread/src/ping.rs
+++ b/openthread/src/ping.rs
@@ -1,0 +1,251 @@
+//! Ping sender API: ICMPv6 Echo diagnostics from inside the OpenThread stack
+//! (`otPingSenderPing`) — round-trip times, loss and per-reply details without
+//! hand-rolling ICMPv6 over the raw IPv6 API.
+
+use core::ffi::c_void;
+use core::future::poll_fn;
+use core::net::Ipv6Addr;
+
+use crate::sys::{
+    otError_OT_ERROR_BUSY, otInstance, otIp6Address, otIp6Address__bindgen_ty_1, otPingSenderPing,
+    otPingSenderReply, otPingSenderStatistics, otPingSenderStop,
+};
+use crate::{ot, OpenThread, OtContext, OtError};
+
+/// The configuration of a ping run (`otPingSenderConfig`).
+///
+/// All fields except [`destination`](Self::destination) may be left at their
+/// zero/`None` values, in which case OpenThread's defaults apply (one request,
+/// 8 data bytes, 1 s interval).
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PingConfig {
+    /// Destination address to ping.
+    pub destination: Ipv6Addr,
+    /// Source address of the ping; `None` to let OpenThread pick one.
+    pub source: Option<Ipv6Addr>,
+    /// Data size (# of bytes) of the echo payload, excluding the IPv6/ICMPv6
+    /// headers. Zero for the default.
+    pub size: u16,
+    /// Number of ping requests to send. Zero for the default (one).
+    pub count: u16,
+    /// Interval between requests, in milliseconds. Zero for the default.
+    pub interval_millis: u32,
+    /// Time to wait for the final reply after sending the final request, in
+    /// milliseconds. Zero for the default.
+    pub timeout_millis: u16,
+    /// Hop limit; zero for the default (unless
+    /// [`allow_zero_hop_limit`](Self::allow_zero_hop_limit) is set).
+    pub hop_limit: u8,
+    /// Interpret a [`hop_limit`](Self::hop_limit) of zero as a literal zero
+    /// hop limit rather than "use the default".
+    pub allow_zero_hop_limit: bool,
+    /// Allow pings to a multicast group the device itself is subscribed to to
+    /// be looped back.
+    pub multicast_loop: bool,
+}
+
+impl PingConfig {
+    /// Create a new `PingConfig` for pinging `destination`, with OpenThread's
+    /// defaults for everything else.
+    pub const fn new(destination: Ipv6Addr) -> Self {
+        Self {
+            destination,
+            source: None,
+            size: 0,
+            count: 0,
+            interval_millis: 0,
+            timeout_millis: 0,
+            hop_limit: 0,
+            allow_zero_hop_limit: false,
+            multicast_loop: false,
+        }
+    }
+}
+
+/// A single ping reply (`otPingSenderReply`).
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PingReply {
+    /// The address the reply was received from.
+    pub sender: Ipv6Addr,
+    /// Round-trip time, in milliseconds.
+    pub round_trip_time_millis: u16,
+    /// Reply data size (# of bytes), excluding the IPv6/ICMPv6 headers.
+    pub size: u16,
+    /// Sequence number.
+    pub sequence_number: u16,
+    /// Hop limit of the reply.
+    pub hop_limit: u8,
+}
+
+impl From<&otPingSenderReply> for PingReply {
+    fn from(reply: &otPingSenderReply) -> Self {
+        Self {
+            sender: Ipv6Addr::from(unsafe { reply.mSenderAddress.mFields.m8 }),
+            round_trip_time_millis: reply.mRoundTripTime,
+            size: reply.mSize,
+            sequence_number: reply.mSequenceNumber,
+            hop_limit: reply.mHopLimit,
+        }
+    }
+}
+
+/// The statistics of a completed ping run (`otPingSenderStatistics`), returned
+/// by [`OpenThread::ping`].
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PingStatistics {
+    /// The number of ping requests sent.
+    pub sent_count: u16,
+    /// The number of ping replies received.
+    pub received_count: u16,
+    /// The total round-trip time of all replies, in milliseconds.
+    pub total_round_trip_time_millis: u32,
+    /// The minimum round-trip time among the replies, in milliseconds.
+    pub min_round_trip_time_millis: u16,
+    /// The maximum round-trip time among the replies, in milliseconds.
+    pub max_round_trip_time_millis: u16,
+    /// Whether the destination was a multicast address.
+    pub is_multicast: bool,
+}
+
+impl From<&otPingSenderStatistics> for PingStatistics {
+    fn from(stats: &otPingSenderStatistics) -> Self {
+        Self {
+            sent_count: stats.mSentCount,
+            received_count: stats.mReceivedCount,
+            total_round_trip_time_millis: stats.mTotalRoundTripTime,
+            min_round_trip_time_millis: stats.mMinRoundTripTime,
+            max_round_trip_time_millis: stats.mMaxRoundTripTime,
+            is_multicast: stats.mIsMulticast,
+        }
+    }
+}
+
+fn to_ot_ip6_addr(addr: Ipv6Addr) -> otIp6Address {
+    otIp6Address {
+        mFields: otIp6Address__bindgen_ty_1 { m8: addr.octets() },
+    }
+}
+
+impl<'a> OpenThread<'a> {
+    /// Ping the destination described by `config`, invoking `f` for each
+    /// received reply, and return the run's statistics once it completes
+    /// (`otPingSenderPing`).
+    ///
+    /// The device must be attached to a Thread network for anything beyond
+    /// pinging its own addresses to succeed.
+    ///
+    /// Only one ping run can be in flight at a time; a concurrent call is
+    /// reported as a `BUSY` error. Dropping the returned future cancels the
+    /// ping in progress (`otPingSenderStop`).
+    ///
+    /// NOTE: The future returned by this method is currently NOT
+    /// `core::mem::forget` safe. Its constructor MUST run, so don't call
+    /// `core::mem::forget` on it.
+    pub async fn ping<F>(&self, config: &PingConfig, mut f: F) -> Result<PingStatistics, OtError>
+    where
+        F: FnMut(&PingReply),
+    {
+        {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            if state.ot.ping_callback.is_some() {
+                warn!("Another ping in progress");
+                return Err(OtError::new(otError_OT_ERROR_BUSY));
+            }
+
+            // Clear any stale completion left over from a prior ping whose
+            // future was dropped after the callback signalled but before
+            // `poll_wait` consumed it.
+            state.ot.ping_done.reset();
+
+            {
+                let f: &mut dyn FnMut(&PingReply) = &mut f;
+
+                state.ot.ping_callback = Some(unsafe {
+                    core::mem::transmute::<&mut dyn FnMut(&PingReply), &'a mut dyn FnMut(&PingReply)>(
+                        f,
+                    )
+                });
+
+                let raw_config = crate::sys::otPingSenderConfig {
+                    mSource: to_ot_ip6_addr(config.source.unwrap_or(Ipv6Addr::UNSPECIFIED)),
+                    mDestination: to_ot_ip6_addr(config.destination),
+                    mReplyCallback: Some(Self::plat_c_ping_reply_callback),
+                    mStatisticsCallback: Some(Self::plat_c_ping_statistics_callback),
+                    mCallbackContext: state.ot.instance as *mut _,
+                    mSize: config.size,
+                    mCount: config.count,
+                    mInterval: config.interval_millis,
+                    mTimeout: config.timeout_millis,
+                    mHopLimit: config.hop_limit,
+                    mAllowZeroHopLimit: config.allow_zero_hop_limit,
+                    mMulticastLoop: config.multicast_loop,
+                };
+
+                let res = ot!(unsafe { otPingSenderPing(state.ot.instance, &raw_config) });
+                if res.is_err() {
+                    // Failed to start - drop the stashed closure reference.
+                    state.ot.ping_callback = None;
+                    res?;
+                }
+            }
+        }
+
+        // Cancel-safety: if this future is dropped before the run completes,
+        // stop the sender and drop the stashed (lifetime-erased) `F` reference.
+        // See the forget-safety note in `OpenThread::scan` - the same caveat
+        // applies to the closure reference stashed here.
+        let _guard = scopeguard::guard((), |_| {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            unsafe { otPingSenderStop(state.ot.instance) };
+
+            state.ot.ping_callback = None;
+        });
+
+        let statistics =
+            poll_fn(move |cx| self.activate().state().ot.ping_done.poll_wait(cx)).await;
+
+        Ok(statistics)
+    }
+
+    unsafe extern "C" fn plat_c_ping_reply_callback(
+        reply: *const otPingSenderReply,
+        context: *mut c_void,
+    ) {
+        let instance = context as *mut otInstance;
+
+        let mut ot = OtContext::callback(instance);
+        let state = ot.state();
+
+        let Some(reply) = (unsafe { reply.as_ref() }) else {
+            return;
+        };
+
+        if let Some(f) = state.ot.ping_callback.as_mut() {
+            f(&reply.into());
+        }
+    }
+
+    unsafe extern "C" fn plat_c_ping_statistics_callback(
+        statistics: *const otPingSenderStatistics,
+        context: *mut c_void,
+    ) {
+        let instance = context as *mut otInstance;
+
+        let mut ot = OtContext::callback(instance);
+        let state = ot.state();
+
+        let Some(statistics) = (unsafe { statistics.as_ref() }) else {
+            return;
+        };
+
+        state.ot.ping_callback = None;
+        state.ot.ping_done.signal(statistics.into());
+    }
+}

--- a/openthread/src/radio.rs
+++ b/openthread/src/radio.rs
@@ -305,8 +305,26 @@ pub trait Radio {
     // TODO
     //fn set_enabled(&mut self, enabled: bool) -> Result<(), Self::Error>;
 
-    // TODO
-    //fn energy_scan(&mut self, channel: u8, duration: u16) -> Result<(), Self::Error>;
+    /// Perform an energy scan on `channel`: measure the energy observed over
+    /// `duration_millis` and return the maximum RSSI, in dBm.
+    ///
+    /// A radio that cannot measure channel energy keeps this default
+    /// implementation, which completes immediately reporting "no measurement"
+    /// (the 802.15.4 "invalid RSSI" value, +127 dBm); OpenThread omits such
+    /// channels from the energy scan results, so a scan on such a radio
+    /// cleanly yields *no* results rather than fake readings.
+    ///
+    /// NOTE: OpenThread's energy scan requests are always routed here,
+    /// regardless of whether the radio reports [`Capabilities::ENERGY_SCAN`]
+    /// (see the initial-`radio_caps` discussion in `lib.rs`: OpenThread
+    /// snapshots the radio capabilities before the actual `Radio` instance is
+    /// known, and its software-sampling fallback needs a synchronous RSSI
+    /// read, which is unimplementable on top of this async trait).
+    async fn energy_scan(&mut self, channel: u8, duration_millis: u16) -> Result<i8, Self::Error> {
+        let _ = (channel, duration_millis);
+
+        Ok(crate::sys::OT_RADIO_RSSI_INVALID as i8)
+    }
 
     /// Transmit a radio frame.
     ///
@@ -347,6 +365,10 @@ where
 
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         T::set_config(self, config).await
+    }
+
+    async fn energy_scan(&mut self, channel: u8, duration_millis: u16) -> Result<i8, Self::Error> {
+        T::energy_scan(self, channel, duration_millis).await
     }
 
     async fn transmit(
@@ -520,6 +542,14 @@ where
         self.ext_addr = config.ext_addr.unwrap_or(MacHeader::BROADCAST_EXT_ADDR);
 
         Ok(())
+    }
+
+    async fn energy_scan(&mut self, channel: u8, duration_millis: u16) -> Result<i8, Self::Error> {
+        // Energy scan involves no MAC-layer processing - pass through.
+        self.radio
+            .energy_scan(channel, duration_millis)
+            .await
+            .map_err(Self::Error::Io)
     }
 
     async fn transmit(
@@ -843,6 +873,13 @@ impl Radio for ProxyRadio<'_> {
         // radio in a `MacRadio`, so the MAC set it publishes is the full offload
         // set; the runner must be running for TX/RX to work at all, so this
         // resolves once it has brought the radio up.)
+        //
+        // TODO: the proxy's request/response protocol carries only TX/RX, so
+        // `Radio::energy_scan` is *not* forwarded to the PHY radio: the proxy
+        // keeps the default implementation and reports "no measurement". This
+        // costs nothing today (no proxied radio can measure channel energy —
+        // see the `esp`/`nrf` notes); forward it through the protocol if one
+        // ever can.
         Ok(self.caps.wait().await)
     }
 

--- a/openthread/src/radio/esp.rs
+++ b/openthread/src/radio/esp.rs
@@ -115,6 +115,11 @@ impl Radio for EspRadio<'_> {
     async fn init(&mut self) -> Result<RadioCaps, Self::Error> {
         // Fixed, statically-known capabilities of the ESP 802.15.4 radio: it does
         // full MAC offload (auto-ACK, filtering) and CSMA/ACK-timeout in hardware.
+        //
+        // No `ENERGY_SCAN` (and no `Radio::energy_scan` impl): the ESP 802.15.4
+        // hardware does have an energy detector, but `esp-radio`'s `Ieee802154`
+        // driver does not expose it (as of 0.18). Until it does, energy scans on
+        // this radio yield no measurements (see `Radio::energy_scan`).
         Ok(RadioCaps {
             phy: Capabilities::ACK_TIMEOUT.union(Capabilities::CSMA_BACKOFF),
             // .union(Capabilities::RX_ON_WHEN_IDLE) TODO: Depends on coex being off in ESP-IDF

--- a/openthread/src/radio/nrf.rs
+++ b/openthread/src/radio/nrf.rs
@@ -89,6 +89,13 @@ impl Radio for NrfRadio<'_> {
     async fn init(&mut self) -> Result<RadioCaps, Self::Error> {
         // The nRF radio has no PHY or MAC offloading capabilities of its own;
         // OpenThread / `MacRadio` handle everything in software.
+        //
+        // No `ENERGY_SCAN` (and no `Radio::energy_scan` impl) either: the nRF
+        // RADIO peripheral can sample channel energy (EDSAMPLE), but
+        // `embassy-nrf`'s IEEE 802.15.4 driver does not expose it (as of 0.10;
+        // energy detection is only used internally as a CCA mode). Until it
+        // does, energy scans on this radio yield no measurements (see
+        // `Radio::energy_scan`).
         Ok(RadioCaps::default())
     }
 

--- a/openthread/src/radio/spinel.rs
+++ b/openthread/src/radio/spinel.rs
@@ -150,6 +150,10 @@ const PROP_PROTOCOL_VERSION: u32 = 1;
 const PROP_CAPS: u32 = 5;
 const PROP_HWADDR: u32 = 8;
 const PROP_PHY_ENABLED: u32 = 0x20;
+const PROP_MAC_SCAN_STATE: u32 = 0x30;
+const PROP_MAC_SCAN_MASK: u32 = 0x31;
+const PROP_MAC_SCAN_PERIOD: u32 = 0x32;
+const PROP_MAC_ENERGY_SCAN_RESULT: u32 = 0x39;
 /// `SPINEL_PROP_RADIO_CAPS` — the RCP's `otRadioCaps` bitmask (packed-uint).
 const PROP_RADIO_CAPS: u32 = 0x1207;
 const PROP_PHY_CHAN: u32 = 0x21;
@@ -170,6 +174,10 @@ const CAP_MAC_RAW: u32 = 513;
 
 /// The single interface id we use (non-multipan host).
 const SPINEL_IID: u8 = 0;
+
+/// `SPINEL_SCAN_STATE_ENERGY` — the [`PROP_MAC_SCAN_STATE`] value starting an
+/// energy scan.
+const SCAN_STATE_ENERGY: u8 = 2;
 
 // Structural spinel constants, from the (bindgen-generated) `crate::sys`
 // bindings of `spinel.h`. Re-typed to the `u32`/`u8` this driver uses (bindgen
@@ -370,9 +378,19 @@ impl TidSet {
 /// `PROP_RADIO_CAPS`, which the `Radio` trait's compile-time `const CAPS` cannot
 /// yet carry (see the `CAPS` impl for the follow-up). Under-claiming here is
 /// safe: OpenThread performs any unclaimed capability in software.
+///
+/// `ENERGY_SCAN` is part of the baseline even though it is not strictly part of
+/// the transmit contract: the scan runs on the *RCP's* MAC sub-layer (via the
+/// `MAC_SCAN_*` properties), which measures with the radio hardware's energy
+/// detector — or, failing that, samples real RSSI on the RCP itself — so
+/// forwarding is the only path to real measurements (the host cannot sample a
+/// remote radio's RSSI synchronously). An RCP that cannot scan at all rejects
+/// the scan-state write, which [`SpinelRadio::energy_scan`] surfaces as an
+/// error (reported to OpenThread as an "invalid RSSI" scan result).
 const SPINEL_RADIO_CAPS: Capabilities = Capabilities::ACK_TIMEOUT
     .union(Capabilities::CSMA_BACKOFF)
-    .union(Capabilities::TRANSMIT_RETRIES);
+    .union(Capabilities::TRANSMIT_RETRIES)
+    .union(Capabilities::ENERGY_SCAN);
 
 /// The MAC-offload capabilities we advertise to OpenThread.
 ///
@@ -880,6 +898,13 @@ where
             .await?;
         self.caps = Capabilities::from_bits_truncate(caps_bits as u16) | SPINEL_RADIO_CAPS;
 
+        info!(
+            "RCP radio caps: 0x{:04x} (reported 0x{:08x} + baseline 0x{:04x})",
+            self.caps.bits(),
+            caps_bits,
+            SPINEL_RADIO_CAPS.bits()
+        );
+
         // Enable the PHY.
         self.set_prop(PROP_PHY_ENABLED, &[1]).await?;
 
@@ -1080,6 +1105,68 @@ where
     async fn set_config(&mut self, config: &Config) -> Result<(), Self::Error> {
         self.ensure_init().await?;
         self.flush_config(config).await
+    }
+
+    async fn energy_scan(&mut self, channel: u8, duration_millis: u16) -> Result<i8, Self::Error> {
+        self.ensure_init().await?;
+
+        // Configure and start the scan on the RCP, checking each ack: an RCP
+        // that cannot scan at all (its radio lacks an energy detector and its
+        // firmware was built without the software-scan fallback) rejects the
+        // scan-state write with a `LAST_STATUS` error, and that must fail the
+        // scan rather than leave us waiting for a result that never comes.
+        let period = duration_millis.to_le_bytes();
+
+        for (prop, payload) in [
+            (PROP_MAC_SCAN_MASK, &[channel][..]),
+            (PROP_MAC_SCAN_PERIOD, &period[..]),
+            (PROP_MAC_SCAN_STATE, &[SCAN_STATE_ENERGY][..]),
+        ] {
+            let (rprop, _off) = self
+                .send_prop_await(prop, payload, RESPONSE_TIMEOUT)
+                .await?;
+            if rprop != prop {
+                // The ack did not echo the property we set - typically a
+                // `LAST_STATUS` carrying an error such as "unimplemented".
+                warn!(
+                    "Energy scan: RCP rejected the 0x{:02x} property write",
+                    prop
+                );
+                return Err(RadioErrorKind::Other);
+            }
+        }
+
+        // Wait for the unsolicited per-channel scan result notification,
+        // stashing any radio frames received meanwhile (see `try_stash_rx`).
+        //
+        // If this future is dropped before the result arrives (e.g. the radio
+        // runner preempts the scan with a new command), the stray notification
+        // is simply ignored by the other wire-read loops later.
+        let timeout = RESPONSE_TIMEOUT + Duration::from_millis(duration_millis as u64);
+
+        loop {
+            let frame_len = self.recv_frame(timeout).await?;
+
+            if self.try_stash_rx(frame_len) {
+                continue;
+            }
+
+            let frame = &self.rx_frame[..frame_len];
+            let Some((_tid, rcmd, rprop, off)) = spinel_parse_header(frame) else {
+                continue;
+            };
+
+            if rcmd == CMD_PROP_VALUE_IS && rprop == PROP_MAC_ENERGY_SCAN_RESULT {
+                // Payload ("Cc"): channel (u8) + max RSSI (i8).
+                let body = &frame[off..];
+                if body.len() < 2 {
+                    return Err(RadioErrorKind::Other);
+                }
+
+                return Ok(body[1] as i8);
+            }
+            // Other frames (e.g. the scan-state-back-to-idle notification) — ignore.
+        }
     }
 
     async fn transmit(

--- a/openthread/src/scan.rs
+++ b/openthread/src/scan.rs
@@ -3,14 +3,15 @@ use core::future::poll_fn;
 
 use crate::fmt::bitflags;
 use crate::sys::{
-    otActiveScanResult, otError_OT_ERROR_BUSY, otInstance, otLinkActiveScan,
-    otLinkIsActiveScanInProgress, OT_CHANNEL_10_MASK, OT_CHANNEL_11_MASK, OT_CHANNEL_12_MASK,
-    OT_CHANNEL_13_MASK, OT_CHANNEL_14_MASK, OT_CHANNEL_15_MASK, OT_CHANNEL_16_MASK,
-    OT_CHANNEL_17_MASK, OT_CHANNEL_18_MASK, OT_CHANNEL_19_MASK, OT_CHANNEL_1_MASK,
-    OT_CHANNEL_20_MASK, OT_CHANNEL_21_MASK, OT_CHANNEL_22_MASK, OT_CHANNEL_23_MASK,
-    OT_CHANNEL_24_MASK, OT_CHANNEL_25_MASK, OT_CHANNEL_26_MASK, OT_CHANNEL_2_MASK,
-    OT_CHANNEL_3_MASK, OT_CHANNEL_4_MASK, OT_CHANNEL_5_MASK, OT_CHANNEL_6_MASK, OT_CHANNEL_7_MASK,
-    OT_CHANNEL_8_MASK, OT_CHANNEL_9_MASK,
+    otActiveScanResult, otEnergyScanResult, otError_OT_ERROR_BUSY, otInstance, otLinkActiveScan,
+    otLinkEnergyScan, otLinkIsActiveScanInProgress, otLinkIsEnergyScanInProgress,
+    OT_CHANNEL_10_MASK, OT_CHANNEL_11_MASK, OT_CHANNEL_12_MASK, OT_CHANNEL_13_MASK,
+    OT_CHANNEL_14_MASK, OT_CHANNEL_15_MASK, OT_CHANNEL_16_MASK, OT_CHANNEL_17_MASK,
+    OT_CHANNEL_18_MASK, OT_CHANNEL_19_MASK, OT_CHANNEL_1_MASK, OT_CHANNEL_20_MASK,
+    OT_CHANNEL_21_MASK, OT_CHANNEL_22_MASK, OT_CHANNEL_23_MASK, OT_CHANNEL_24_MASK,
+    OT_CHANNEL_25_MASK, OT_CHANNEL_26_MASK, OT_CHANNEL_2_MASK, OT_CHANNEL_3_MASK,
+    OT_CHANNEL_4_MASK, OT_CHANNEL_5_MASK, OT_CHANNEL_6_MASK, OT_CHANNEL_7_MASK, OT_CHANNEL_8_MASK,
+    OT_CHANNEL_9_MASK,
 };
 use crate::{ot, OpenThread, OtContext, OtError};
 
@@ -77,6 +78,27 @@ pub struct ScanResult<'a> {
     pub native_commissioner: bool,
     /// Discovery Response
     pub discover: bool,
+}
+
+/// An energy scan result for a single channel: the maximum RSSI observed on
+/// the channel over the scan duration. Used e.g. to pick the quietest channel
+/// before forming a new network.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct EnergyScanResult {
+    /// IEEE 802.15.4 Channel
+    pub channel: u8,
+    /// The maximum RSSI observed on the channel (dBm)
+    pub max_rssi: i8,
+}
+
+impl From<&otEnergyScanResult> for EnergyScanResult {
+    fn from(result: &otEnergyScanResult) -> Self {
+        Self {
+            channel: result.mChannel,
+            max_rssi: result.mMaxRssi,
+        }
+    }
 }
 
 impl<'a> From<&'a otActiveScanResult> for ScanResult<'a> {
@@ -216,6 +238,108 @@ impl<'a> OpenThread<'a> {
         if last {
             state.ot.scan_callback = None;
             state.ot.scan_done.signal(());
+        }
+    }
+
+    /// Perform an IEEE 802.15.4 energy scan: measure the maximum RSSI on each
+    /// of the specified channels for the specified duration (`otLinkEnergyScan`).
+    ///
+    /// Useful e.g. for picking the quietest channel before forming a new
+    /// network (see [`OpenThread::create_new_network_dataset`], `ftd` only).
+    ///
+    /// Arguments:
+    /// - `channels`: The channel mask to scan.
+    /// - `duration_millis`: The scan duration per channel, in milliseconds.
+    /// - `f`: A closure that will be called with each channel's result, and
+    ///   finally - with `None` - when the scan is complete.
+    ///
+    /// NOTE: The future returned by this method is currently NOT `core::mem::forget`
+    /// safe. Its constructor MUST run, so don't call `core::mem::forget` on it.
+    pub async fn energy_scan<F>(
+        &self,
+        channels: Channels,
+        duration_millis: u16,
+        mut f: F,
+    ) -> Result<(), OtError>
+    where
+        F: FnMut(Option<&EnergyScanResult>),
+    {
+        {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            let in_progress = unsafe { otLinkIsEnergyScanInProgress(state.ot.instance) };
+
+            if in_progress {
+                warn!("Another energy scan in progress");
+                return Err(OtError::new(otError_OT_ERROR_BUSY));
+            }
+
+            // Clear any stale completion left over from a prior scan whose future
+            // was dropped after the callback signalled but before `poll_wait`
+            // consumed it - otherwise this scan would complete immediately.
+            state.ot.energy_scan_done.reset();
+
+            {
+                let f: &mut dyn FnMut(Option<&EnergyScanResult>) = &mut f;
+
+                let energy_scan_callback = &mut state.ot.energy_scan_callback;
+                *energy_scan_callback = Some(unsafe {
+                    core::mem::transmute::<
+                        &mut dyn FnMut(Option<&EnergyScanResult>),
+                        &'a mut dyn FnMut(Option<&EnergyScanResult>),
+                    >(f)
+                });
+
+                ot!(unsafe {
+                    otLinkEnergyScan(
+                        state.ot.instance,
+                        channels.bits(),
+                        duration_millis,
+                        Some(Self::plat_c_energy_scan_callback),
+                        state.ot.instance as *mut _ as *mut _,
+                    )
+                })?;
+            }
+        }
+
+        // See the forget-safety note in `scan` above: the same caveat applies to
+        // the lifetime-erased `F` closure reference stashed here.
+        let _guard = scopeguard::guard((), |_| {
+            let mut ot = self.activate();
+            let state = ot.state();
+
+            let energy_scan_callback = &mut state.ot.energy_scan_callback;
+
+            *energy_scan_callback = None;
+        });
+
+        poll_fn(move |cx| self.activate().state().ot.energy_scan_done.poll_wait(cx)).await;
+
+        Ok(())
+    }
+
+    unsafe extern "C" fn plat_c_energy_scan_callback(
+        scan_result: *mut otEnergyScanResult,
+        context: *mut c_void,
+    ) {
+        let instance = context as *mut otInstance;
+
+        let mut ot = OtContext::callback(instance);
+        let state = ot.state();
+
+        let scan_result = unsafe { scan_result.as_ref() };
+        let last = scan_result.is_none();
+
+        let scan_result = scan_result.map(|s| s.into());
+
+        if let Some(f) = state.ot.energy_scan_callback.as_mut() {
+            f(scan_result.as_ref());
+        }
+
+        if last {
+            state.ot.energy_scan_callback = None;
+            state.ot.energy_scan_done.signal(());
         }
     }
 }


### PR DESCRIPTION
#### New functionality
- Energy scan
- New network establishment
- Thread Joiner
- `OpenThread::ping` utility

#### Tested on real hardware (ESP32-C6 RCP dongle)

- **Energy scan** — fully
- **`create_new_network_dataset`** — fully
- **Ping** — fully
- **Joiner** — partially: real per-channel discovery scan on air (~5 s), clean
  `NOT_FOUND`, retry loop, cancel path; `INVALID_STATE` error path (netif down)
- **TX/RX regression** after the radio-trait/caps changes — via re-running
  attach + ping

## Not tested

- **Joiner success leg**: the EC-JPAKE/DTLS handshake and credential download —
  needs a live Commissioner admitting the device (OTBR `commissioner start` +
  `joiner add`; consumer hubs don't expose this)
- **Energy scan / ping / joiner on the esp/nrf SoC** (no reason not to work, except for the energy scan - esp/nrf scans are by design empty — the HALs lack energy-detect APIs)
- **Ping edge configs**: multicast destinations, custom source address,
  zero-hop-limit and other non-default `PingConfig` fields
- **Preemption paths**: energy scan or ping interrupted mid-run by a competing
  radio command (code path exists, never exercised)
- **`ftd`+`rcp` on embedded targets** (host-only validation; prebuilt-invalidation
  for `joiner` verified on the host build only)