### PR TITLE
Report Thread 1.4 as the supported protocol

### DIFF
--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -63,3 +63,8 @@ required-features = ["ftd"]
 path = "./src/bin/joiner.rs"
 name = "joiner"
 required-features = ["joiner"]
+
+[[bin]]
+path = "./src/bin/become_router.rs"
+name = "become_router"
+required-features = ["ftd"]

--- a/examples/std/src/bin/become_router.rs
+++ b/examples/std/src/bin/become_router.rs
@@ -1,0 +1,136 @@
+//! Host example driving a remote OpenThread RCP over serial that attaches as a
+//! child and then **forces a router upgrade** via [`OpenThread::become_router`],
+//! instead of waiting for OpenThread's jittered automatic upgrade.
+//!
+//! Its purpose is to deterministically exercise the child-to-router role
+//! transition — which is when OpenThread calls `otPlatRadioSetAlternateShortAddress`
+//! with the node's old (child) RLOC16 (the alternate short address), then clears
+//! it ~8 s later. Run with `RUST_LOG=info` and watch for the
+//! `Plat radio set alternate short address callback` line.
+//!
+//! Needs the `ftd` feature (only a Full Thread Device can become a router):
+//! `cargo run --features ftd --bin become_router`
+//!
+//! Set the serial device with `RCP_SERIAL` (default `/dev/ttyACM0`), the baud
+//! rate with `RCP_BAUD` (default 115200) and, optionally, `THREAD_DATASET`.
+
+use embassy_executor::{Executor, Spawner};
+
+use log::{info, warn};
+
+use openthread::spinel::{
+    SerialPort, SpinelRadio, SpinelRadioResources, UartSpinelTransport, UartTransportResources,
+};
+use openthread::{DeviceRole, OpenThread, OtResources, SimpleRamSettings};
+
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+
+use static_cell::{ConstStaticCell, StaticCell};
+
+// Linked for its `utoa`/`strtoul` C symbols, which OpenThread's C references.
+use tinyrlibc as _;
+
+const DEFAULT_SERIAL: &str = "/dev/ttyACM0";
+const DEFAULT_BAUD: u32 = 115_200;
+
+const THREAD_DATASET: &str = match option_env!("THREAD_DATASET") {
+    Some(dataset) => dataset,
+    None => "000300001901020fd80208b566147d38e384200e080000639c5d67a3bd0510c490f58d4be0d5eaeb0f09b395d1ae17030d4e4553542d50414e2d304644380708fd7d4f8232cb00000410a7e08419ae47c177fb91bcfcec789aa50c0402a0f77835060004001fffe0",
+};
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| spawner.spawn(main_task(spawner).unwrap()));
+}
+
+#[embassy_executor::task]
+async fn main_task(spawner: Spawner) {
+    let serial_path = std::env::var("RCP_SERIAL").unwrap_or_else(|_| DEFAULT_SERIAL.into());
+    let baud = std::env::var("RCP_BAUD")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_BAUD);
+
+    info!("Starting; opening RCP serial {serial_path} @ {baud} baud");
+
+    static RNG: StaticCell<StdRng> = StaticCell::new();
+    let rng = RNG.init(StdRng::from_os_rng());
+
+    let mut ieee_eui64 = [0u8; 8];
+    rng.fill_bytes(&mut ieee_eui64);
+
+    static OT_RESOURCES: StaticCell<OtResources> = StaticCell::new();
+    static OT_SETTINGS_BUF: StaticCell<[u8; 1024]> = StaticCell::new();
+    static OT_SETTINGS: StaticCell<SimpleRamSettings> = StaticCell::new();
+
+    let ot_resources = OT_RESOURCES.init(OtResources::new());
+    let ot_settings_buf = OT_SETTINGS_BUF.init([0; 1024]);
+    let ot_settings = OT_SETTINGS.init(SimpleRamSettings::new(ot_settings_buf));
+
+    let ot = OpenThread::new(ieee_eui64, rng, ot_settings, ot_resources).unwrap();
+
+    static RADIO_RESOURCES: ConstStaticCell<SpinelRadioResources> =
+        ConstStaticCell::new(SpinelRadioResources::new());
+    static UART_RESOURCES: ConstStaticCell<UartTransportResources> =
+        ConstStaticCell::new(UartTransportResources::new());
+
+    let serial = SerialPort::open(&serial_path, baud).expect("open RCP serial");
+    let radio = SpinelRadio::new(
+        UartSpinelTransport::new(serial, UART_RESOURCES.take()),
+        RADIO_RESOURCES.take(),
+    );
+
+    spawner.spawn(run_ot(ot.clone(), radio).unwrap());
+
+    info!("Dataset: {THREAD_DATASET}");
+
+    ot.set_active_dataset_tlv_hexstr(THREAD_DATASET).unwrap();
+    ot.enable_ipv6(true).unwrap();
+    ot.enable_thread(true).unwrap();
+
+    // Wait until we have attached as a child.
+    loop {
+        let role = ot.device_role();
+        info!("Role: {role:?} (eligible: {})", ot.router_eligible());
+        if matches!(
+            role,
+            DeviceRole::Child | DeviceRole::Router | DeviceRole::Leader
+        ) {
+            break;
+        }
+        ot.wait_changed().await;
+    }
+
+    // Force the router upgrade. If we are already a router/leader this is a
+    // harmless no-op error; if we are a child, it kicks off the child->router
+    // transition (which drives `otPlatRadioSetAlternateShortAddress`).
+    if matches!(ot.device_role(), DeviceRole::Child) {
+        info!("Child attached — forcing router upgrade via become_router()...");
+        match ot.become_router() {
+            Ok(()) => info!("become_router(): Address Solicit sent"),
+            Err(e) => warn!("become_router() failed: {e:?}"),
+        }
+    }
+
+    // Report every subsequent role change.
+    loop {
+        ot.wait_changed().await;
+        info!("Role now: {:?}", ot.device_role());
+    }
+}
+
+#[embassy_executor::task]
+async fn run_ot(
+    ot: OpenThread<'static>,
+    radio: SpinelRadio<'static, UartSpinelTransport<'static, SerialPort>>,
+) -> ! {
+    ot.run(radio).await
+}

--- a/openthread-sys/CHANGELOG.md
+++ b/openthread-sys/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* The default MbedTLS backend is now OpenThread's own **bundled** MbedTLS, not the external `mbedtls-rs-sys` crate. A default-features build reuses the committed prebuilt libraries and needs **no C toolchain** (clang/cmake/ninja).
+* Advertise **Thread 1.4** instead of Thread 1.1 (#103)
+  * The stack now reports Thread version 1.4 (`OpenThread::thread_version` returns 4; the highest the vendored OpenThread supports). Thread 1.3+ is the floor Matter-over-Thread expects; for a plain node (no Border Router, no TREL) the on-air/radio contract is unchanged past 1.2, so this is effectively a version bump plus a few benign internal behaviors (e.g. a more thorough parent search at attach).
+  * CSL is deliberately **not** compiled in: both `OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE` (which otherwise defaults on at >= 1.2) and `OT_CSL_RECEIVER` are forced off. This keeps the radio-platform contract identical to 1.1 — no `EnableCsl` / `ReceiveAt` / `GetCslAccuracy` callbacks are referenced — so every existing `Radio` driver keeps working unchanged. Low-power CSL (SSED) remains a future opt-in.
+  * HW-validated over an RCP: attach, SRP registration, and a `ping-stress` datapath sweep against a live Border Router.
+* NRF52: Fix a corruption issue where Clang compiled the C code with `short-enums = false`, while bindgen generated bindings with `short-enums = true` (#102)
+* The default MbedTLS backend is now OpenThread's own **bundled** MbedTLS, not the external `mbedtls-rs-sys` crate. A default-features build reuses the committed prebuilt libraries and needs **no C toolchain** (clang/cmake/ninja). (#101)
   * To build OpenThread against the external `mbedtls-rs-sys` instead, enable the `mbedtls-rs-sys` feature. Do this when another crate in the graph already provides `mbedtls-rs-sys` (e.g. `rs-matter`), so a single MbedTLS serves both, or when you need the HW accel capabilities of `mbedtls-rs-sys`.
   * WARNING: do not combine a default (bundled-MbedTLS) OpenThread with a separate `mbedtls-rs-sys` in the same firmware — that links two MbedTLS copies. If your graph needs `mbedtls-rs-sys`, enable this feature so OpenThread reuses it.
 * Remote Radio Support (Spinel-RCP) (#98)

--- a/openthread-sys/gen/builder.rs
+++ b/openthread-sys/gen/builder.rs
@@ -232,8 +232,35 @@ impl OpenThreadBuilder {
             });
         }
 
+        // Thread protocol version advertised and spoken by the stack.
+        //
+        // 1.4 (the latest; 1.3.1 is an alias) — Matter-over-Thread requires >= 1.3,
+        // and for a plain node (no Border Router, no TREL) the on-air/radio
+        // contract does NOT change anywhere past 1.2: no new `otPlatRadio*`
+        // callback is referenced at 1.3/1.4, and the only deltas are benign
+        // internal C++ behaviors (a more thorough parent search at attach,
+        // delay-aware tx-queue management). See `thread-version-and-frame-support`.
+        //
+        // The two CSL flags below are the important part of pinning ">=1.2
+        // WITHOUT the CSL machinery". `OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE`
+        // otherwise DEFAULTS ON at >= 1.2 (see the vendored `src/core/config/mac.h`)
+        // and is a SEPARATE axis from the receiver: the transmitter is the
+        // *parent* side (an FTD scheduling indirect frames to CSL children),
+        // the receiver is the *child* (SSED) side. We want neither yet:
+        //   - CSL_RECEIVER off  -> this node is never a CSL sleepy child.
+        //   - CSL_TRANSMITTER off -> an FTD here never tries to parent CSL
+        //     children, so OT never calls the CSL-parent radio hooks
+        //     (`otPlatRadioGetCslAccuracy`/`GetCslUncertainty`) at runtime.
+        // Together they keep the radio-platform contract identical to 1.1: no
+        // `EnableCsl`/`ReceiveAt`/`GetCsl*` callbacks are referenced or invoked,
+        // so every existing `Radio` driver keeps working unchanged. Enabling CSL
+        // (low-power SSED) is a deliberate future opt-in that also needs the
+        // `Radio` trait to grow the CSL/enh-ACK-security surface.
         config
-            .define("OT_THREAD_VERSION", "1.1")
+            .define("OT_THREAD_VERSION", "1.4")
+            .cflag("-DOPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE=0")
+            .cxxflag("-DOPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE=0")
+            .define("OT_CSL_RECEIVER", "OFF")
             .define("OT_LOG_LEVEL", "NOTE")
             // Build BOTH device types so the prebuilt cache covers MTD and FTD.
             // The actual archives shipped/linked are chosen by the umbrella

--- a/openthread/CHANGELOG.md
+++ b/openthread/CHANGELOG.md
@@ -6,7 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* The default MbedTLS backend is now OpenThread's own **bundled** MbedTLS, not the external `mbedtls-rs-sys` crate. A default-features build reuses the committed prebuilt libraries and needs **no C toolchain** (clang/cmake/ninja).
+* Advertise **Thread 1.4** instead of Thread 1.1 (#103)
+  * The stack now reports Thread version 1.4 (`OpenThread::thread_version` returns 4; the highest the vendored OpenThread supports). Thread 1.3+ is the floor Matter-over-Thread expects; for a plain node (no Border Router, no TREL) the on-air/radio contract is unchanged past 1.2, so this is effectively a version bump plus a few benign internal behaviors (e.g. a more thorough parent search at attach).
+  * CSL is deliberately **not** compiled in: both `OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE` (which otherwise defaults on at >= 1.2) and `OT_CSL_RECEIVER` are forced off. This keeps the radio-platform contract identical to 1.1 — no `EnableCsl` / `ReceiveAt` / `GetCslAccuracy` callbacks are referenced — so every existing `Radio` driver keeps working unchanged. Low-power CSL (SSED) remains a future opt-in.
+  * HW-validated over an RCP: attach, SRP registration, and a `ping-stress` datapath sweep against a live Border Router.
+* Alternate short address support (Thread 1.4 FTD) (#103)
+  * Implements `otPlatRadioSetAlternateShortAddress`, which OpenThread calls during a child-to-router role transition so the node keeps receiving frames addressed to its previous RLOC16 for a short window (~8s). Surfaced as `Config::alt_short_addr`.
+  * Honored by the software `MacRadio` filter, so radios with no MAC offload (e.g. `NrfRadio`) accept both the primary and alternate short address for free. `SpinelRadio` programs the RCP's alternate-short-address property, but only when the RCP advertises the `ALT_SHORT_ADDR` capability (stock RCPs without it fall back to the primary only). `EspRadio` does not yet honor it: `esp-radio` exposes no public multi-PAN / second-short-address API, so the alternate is dropped by the hardware filter for now. In all unsupported cases the alternate is a reliability optimization — peers relearn the new RLOC16 within the window and higher layers retransmit.
+* New APIs for calling into OpenThread directly (#103)
+  * `OpenThread::with_instance`: an `unsafe` escape hatch that runs a closure with the raw `*mut otInstance`, inside an active state scope, for calling OpenThread C APIs this crate does not yet wrap.
+  * `OpenThread::become_router` (`ftd`): request an immediate router upgrade (`otThreadBecomeRouter`) instead of waiting for OpenThread's jittered automatic one. New std example `become_router` demonstrates it (and deterministically exercises the alternate-short-address transition).
+* NRF52: Fix a corruption issue where Clang compiled the C code with `short-enums = false`, while bindgen generated bindings with `short-enums = true` (#102)
+* The default MbedTLS backend is now OpenThread's own **bundled** MbedTLS, not the external `mbedtls-rs-sys` crate. A default-features build reuses the committed prebuilt libraries and needs **no C toolchain** (clang/cmake/ninja). (#101)
   * To build OpenThread against the external `mbedtls-rs-sys` instead, enable the `mbedtls-rs-sys` feature. Do this when another crate in the graph already provides `mbedtls-rs-sys` (e.g. `rs-matter`), so a single MbedTLS serves both, or when you need the HW accel capabilities of `mbedtls-rs-sys`.
   * WARNING: do not combine a default (bundled-MbedTLS) OpenThread with a separate `mbedtls-rs-sys` in the same firmware — that links two MbedTLS copies. If your graph needs `mbedtls-rs-sys`, enable this feature so OpenThread reuses it.
 * Address the Tier 2 API gaps:

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -621,6 +621,24 @@ impl<'a> OpenThread<'a> {
         }
     }
 
+    /// Request that this node become a router (`otThreadBecomeRouter`).
+    ///
+    /// Sends an Address Solicit to the leader to obtain a router ID, promoting a
+    /// router-eligible child to the router role without waiting for OpenThread's
+    /// automatic (jittered) router upgrade. Only meaningful on a Full Thread
+    /// Device that is currently a child and [`router_eligible`](Self::router_eligible).
+    ///
+    /// Returns an error if the node is not eligible or not in a state from which
+    /// it can become a router (e.g. detached, disabled, or already a router or
+    /// leader) — OpenThread reports `OT_ERROR_INVALID_STATE` / `OT_ERROR_NOT_CAPABLE`.
+    #[cfg(feature = "ftd")]
+    pub fn become_router(&self) -> Result<(), OtError> {
+        let mut ot = self.activate();
+        let state = ot.state();
+
+        ot!(unsafe { sys::otThreadBecomeRouter(state.ot.instance) })
+    }
+
     /// Return whether this node is router-eligible (`otThreadIsRouterEligible`).
     ///
     /// Only available on a Full Thread Device (`ftd` feature); a Minimal Thread
@@ -1040,6 +1058,36 @@ impl<'a> OpenThread<'a> {
         }
 
         f(None)
+    }
+
+    /// Run a closure with direct access to the raw `otInstance` pointer.
+    ///
+    /// An escape hatch for calling OpenThread C APIs (`otXxx`) this crate does
+    /// not yet wrap. The closure runs inside an *active* scope — the same state
+    /// activation every high-level method uses — so the platform callbacks
+    /// OpenThread may invoke during the call (alarm, radio, settings, …) are
+    /// wired to this instance. Because activation is scoped to the call, the
+    /// pointer must NOT escape the closure: it is only valid for the duration of
+    /// `f`. The closure's return value is passed back out.
+    ///
+    /// # Safety
+    ///
+    /// The pointer is a live `*mut otInstance`; misusing the C API through it can
+    /// violate the invariants the safe wrapper upholds. In particular:
+    /// - Do not stash the pointer for later use (it is only valid within `f`).
+    /// - Do not re-enter this crate's API from within `f` (e.g. call another
+    ///   `OpenThread` method), as the state is already active — that would
+    ///   attempt a re-entrant activation.
+    /// - Calling an OpenThread API that expects a different device build (e.g. an
+    ///   FTD-only API on an MTD image) is undefined, exactly as in C.
+    pub fn with_instance<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(*mut otInstance) -> R,
+    {
+        let mut ot = self.activate();
+        let state = ot.state();
+
+        f(state.ot.instance)
     }
 
     /// Wait for the OpenThread stack to change its state.
@@ -2626,6 +2674,24 @@ impl<'a> OtContext<'a> {
 
         if state.ot.radio_conf.short_addr != Some(address) {
             state.ot.radio_conf.short_addr = Some(address);
+        }
+    }
+
+    fn plat_radio_set_alternate_short_address(&mut self, address: u16) {
+        // OpenThread clears the alternate with `OT_RADIO_INVALID_SHORT_ADDR`
+        // (0xfffe); map that to `None` (no alternate). Any other value is the
+        // second short address the radio should also accept.
+        let alt = (address != crate::sys::OT_RADIO_INVALID_SHORT_ADDR as u16).then_some(address);
+
+        info!(
+            "Plat radio set alternate short address callback, addr: {:?}",
+            alt
+        );
+
+        let state = self.state();
+
+        if state.ot.radio_conf.alt_short_addr != alt {
+            state.ot.radio_conf.alt_short_addr = alt;
         }
     }
 

--- a/openthread/src/platform.rs
+++ b/openthread/src/platform.rs
@@ -148,6 +148,19 @@ extern "C" fn otPlatRadioSetShortAddress(instance: *const otInstance, address: u
     OtContext::callback(instance).plat_radio_set_short_address(address);
 }
 
+// Alternate short address (FTD, Thread >= 1.2).
+//
+// During a child-to-router role transition an FTD is briefly reachable at BOTH
+// its old (child) RLOC16 and its new (router) RLOC16. OpenThread hands the radio
+// the old address here so frames addressed to it keep being received for a short
+// window (`kAlternateRloc16Timeout`, ~8s), after which the stack clears it (calls
+// this with `OT_RADIO_INVALID_SHORT_ADDR`. It is invoked unconditionally in the
+//FTD `Mac` path (never on MTD, where `--gc-sections` drops it).
+#[no_mangle]
+extern "C" fn otPlatRadioSetAlternateShortAddress(instance: *const otInstance, address: u16) {
+    OtContext::callback(instance).plat_radio_set_alternate_short_address(address);
+}
+
 #[no_mangle]
 extern "C" fn otPlatRadioSetPanId(instance: *const otInstance, pan_id: u16) {
     OtContext::callback(instance).plat_radio_set_pan_id(pan_id);

--- a/openthread/src/platform.rs
+++ b/openthread/src/platform.rs
@@ -154,8 +154,8 @@ extern "C" fn otPlatRadioSetShortAddress(instance: *const otInstance, address: u
 // its old (child) RLOC16 and its new (router) RLOC16. OpenThread hands the radio
 // the old address here so frames addressed to it keep being received for a short
 // window (`kAlternateRloc16Timeout`, ~8s), after which the stack clears it (calls
-// this with `OT_RADIO_INVALID_SHORT_ADDR`. It is invoked unconditionally in the
-//FTD `Mac` path (never on MTD, where `--gc-sections` drops it).
+// this with `OT_RADIO_INVALID_SHORT_ADDR`). It is invoked unconditionally in the
+// FTD `Mac` path (never on MTD, where `--gc-sections` drops it).
 #[no_mangle]
 extern "C" fn otPlatRadioSetAlternateShortAddress(instance: *const otInstance, address: u16) {
     OtContext::callback(instance).plat_radio_set_alternate_short_address(address);

--- a/openthread/src/radio.rs
+++ b/openthread/src/radio.rs
@@ -204,6 +204,19 @@ pub struct Config {
     /// Short address filter
     /// Disregarded if the radio is not capable of filtering by short address.
     pub short_addr: Option<u16>,
+    /// Alternate short address filter.
+    ///
+    /// A *second* short address the radio should also accept frames for, in
+    /// addition to [`short_addr`](Config::short_addr). Used by an FTD during a
+    /// child-to-router role transition, when it is briefly reachable at both its
+    /// old (child) and new (router) RLOC16 (OpenThread sets it via
+    /// `otPlatRadioSetAlternateShortAddress` and clears it ~8s later). `None`
+    /// means "no alternate" — the common case.
+    ///
+    /// Honored by the software [`MacRadio`] filter and by radios that can match a
+    /// second short address; disregarded by radios whose hardware/co-processor
+    /// short-address filter accepts only a single address (see each driver).
+    pub alt_short_addr: Option<u16>,
     /// Extended address filter
     /// Disregarded if the radio is not capable of filtering by extended address.
     pub ext_addr: Option<u64>,
@@ -224,6 +237,7 @@ impl Config {
             rx_when_idle: true,
             pan_id: None,
             short_addr: None,
+            alt_short_addr: None,
             ext_addr: None,
         }
     }
@@ -467,6 +481,10 @@ pub struct MacRadio<R, T> {
     pan_id: u16,
     /// The short address to filter by, if the filter policy allows it.
     short_addr: u16,
+    /// The alternate short address to *also* accept, or `BROADCAST_SHORT_ADDR`
+    /// (`0xffff`) when there is none. A real destination address never equals
+    /// the broadcast sentinel, so an unset alternate never matches — a no-op.
+    alt_short_addr: u16,
     /// The extended address to filter by, if the filter policy allows it.
     ext_addr: u64,
 }
@@ -504,6 +522,7 @@ where
             promiscuous: false,
             pan_id: MacHeader::BROADCAST_PAN_ID,
             short_addr: MacHeader::BROADCAST_SHORT_ADDR,
+            alt_short_addr: MacHeader::BROADCAST_SHORT_ADDR,
             ext_addr: MacHeader::BROADCAST_EXT_ADDR,
         }
     }
@@ -539,6 +558,9 @@ where
         self.promiscuous = config.promiscuous;
         self.pan_id = config.pan_id.unwrap_or(MacHeader::BROADCAST_PAN_ID);
         self.short_addr = config.short_addr.unwrap_or(MacHeader::BROADCAST_SHORT_ADDR);
+        self.alt_short_addr = config
+            .alt_short_addr
+            .unwrap_or(MacHeader::BROADCAST_SHORT_ADDR);
         self.ext_addr = config.ext_addr.unwrap_or(MacHeader::BROADCAST_EXT_ADDR);
 
         Ok(())
@@ -666,6 +688,7 @@ where
                     if !self.mac_caps.contains(MacCapabilities::FILTER_SHORT_ADDR)
                         && self.mac_header.dst_short_addr != MacHeader::BROADCAST_SHORT_ADDR
                         && self.mac_header.dst_short_addr != self.short_addr
+                        && self.mac_header.dst_short_addr != self.alt_short_addr
                     {
                         trace!(
                             "MacRadio, filtering out frame: {}, short address does not match",

--- a/openthread/src/radio/esp.rs
+++ b/openthread/src/radio/esp.rs
@@ -88,6 +88,26 @@ impl<'a> EspRadio<'a> {
             },
             pan_id: config.pan_id,
             short_addr: config.short_addr,
+            // `config.alt_short_addr` (the second short address an FTD accepts
+            // during a child-to-router role transition) is NOT programmed here.
+            //
+            // The ESP 802.15.4 MAC *does* have the hardware for it — up to 4
+            // multi-PAN address-filter slots, so the alternate could live in slot
+            // 1 alongside the primary in slot 0, keeping full hardware filtering
+            // (and hence `MacCapabilities::all()`). But `esp-radio` (0.18) exposes
+            // neither a second short address on `Config` nor its `set_multipan_*`
+            // / `set_short_address(index, …)` primitives publicly (they are in a
+            // private `raw` module). So there is no way to reach slot 1 from here.
+            //
+            // Because `EspRadio` advertises full HW MAC offload, the software
+            // `MacRadio` filter is bypassed too — so on ESP the alternate RLOC16
+            // is simply not honored, and frames to it during the ~8 s transition
+            // window are dropped (recovered by higher-layer retransmission).
+            //
+            // TODO: implement once `esp-radio` gains a public multi-PAN /
+            // second-short-address API (an upstream `esp-radio` addition, akin to
+            // exposing the HW security registers) — then program slot 1 with the
+            // alternate + the primary PAN ID and enable slots 0 and 1.
             ext_addr: config.ext_addr,
             rx_queue_size: self.rx_queue_size,
             ..Default::default()

--- a/openthread/src/radio/nrf.rs
+++ b/openthread/src/radio/nrf.rs
@@ -88,7 +88,13 @@ impl Radio for NrfRadio<'_> {
 
     async fn init(&mut self) -> Result<RadioCaps, Self::Error> {
         // The nRF radio has no PHY or MAC offloading capabilities of its own;
-        // OpenThread / `MacRadio` handle everything in software.
+        // OpenThread / `MacRadio` handle everything in software. (This includes
+        // address filtering, so `Config::alt_short_addr` — the alternate short
+        // address an FTD accepts during a child-to-router transition — is honored
+        // here for free: the `MacRadio` software filter accepts both the primary
+        // and the alternate. Radios that offload short-address filtering to
+        // hardware/firmware only honor the alternate if that layer supports a
+        // second address; this one always does, in software.)
         //
         // No `ENERGY_SCAN` (and no `Radio::energy_scan` impl) either: the nRF
         // RADIO peripheral can sample channel energy (EDSAMPLE), but

--- a/openthread/src/radio/spinel.rs
+++ b/openthread/src/radio/spinel.rs
@@ -160,6 +160,10 @@ const PROP_PHY_CHAN: u32 = 0x21;
 const PROP_PHY_TX_POWER: u32 = 0x25;
 const PROP_MAC_15_4_LADDR: u32 = 0x34;
 const PROP_MAC_15_4_SADDR: u32 = 0x35;
+/// `SPINEL_PROP_MAC_15_4_ALT_SADDR` (`MAC__BEGIN + 12`) — a *second* short
+/// address the RCP's hardware filter should also accept. Only meaningful when the
+/// RCP advertises `OT_RADIO_CAPS_ALT_SHORT_ADDR`; sent only in that case.
+const PROP_MAC_15_4_ALT_SADDR: u32 = 0x3c;
 const PROP_MAC_15_4_PANID: u32 = 0x36;
 const PROP_MAC_RAW_STREAM_ENABLED: u32 = 0x37;
 const PROP_MAC_PROMISCUOUS_MODE: u32 = 0x38;
@@ -952,6 +956,9 @@ where
         let rx_when_idle = [config.rx_when_idle as u8];
         let pan_id = config.pan_id.unwrap_or(0xffff).to_le_bytes();
         let short_addr = config.short_addr.unwrap_or(0xffff).to_le_bytes();
+        // Alternate short address: `0xfffe` (`OT_RADIO_INVALID_SHORT_ADDR`) is the
+        // "no alternate / clear" wire value the RCP expects.
+        let alt_short_addr = config.alt_short_addr.unwrap_or(0xfffe).to_le_bytes();
         // The spinel `MAC_15_4_LADDR` property carries the extended address in
         // *reversed* byte order relative to the bytes `otPlatRadioSetExtendedAddress`
         // hands the platform — which is what `Config::ext_addr` holds, as
@@ -962,7 +969,7 @@ where
         // this order.
         let ext_addr = config.ext_addr.unwrap_or(0).to_be_bytes();
 
-        let mut batch: [(u32, &[u8]); 7] = [(0, &[]); 7];
+        let mut batch: [(u32, &[u8]); 8] = [(0, &[]); 8];
         let mut count = 0;
 
         if changed(|c| c.channel as u64) {
@@ -990,6 +997,16 @@ where
         }
         if changed(|c| c.short_addr.unwrap_or(0xffff) as u64) {
             batch[count] = (PROP_MAC_15_4_SADDR, &short_addr);
+            count += 1;
+        }
+        // Alternate short address — only if the RCP advertises the capability
+        // (mirrors upstream `RadioSpinel::SetAlternateShortAddress`, which gates
+        // the property set on `OT_RADIO_CAPS_ALT_SHORT_ADDR`). Stock RCPs without
+        // it simply never receive the property.
+        if self.caps.contains(Capabilities::ALT_SHORT_ADDR)
+            && changed(|c| c.alt_short_addr.unwrap_or(0xfffe) as u64)
+        {
+            batch[count] = (PROP_MAC_15_4_ALT_SADDR, &alt_short_addr);
             count += 1;
         }
         if changed(|c| c.ext_addr.unwrap_or(0)) {


### PR DESCRIPTION
- We are currently reporting we support Thread 1.1
- This PR raises this all the way to 1.4 (so also support for 1.2 and 1.3)

- 1.2 does introduce something meaningful - CSL (Coordinated Sleepy End Devices) - but this is **outside** the scope of this PR, and all our radios report the CSL profile is NOT supported still.  And CSL might only be useful once `rs-matter` gets the ICD (Intermittently Connected Device) support. And even then, it is questionable and needs research if worth it - "regular" Thread 1.1 Sleepy End Devices that we already support might be "good enough"
(**UPDATE:** Thread 1.1. SED **will** be good enough for the Long Idle Time devices - i.e. sensors that awake every hour or so to report e.g. temp; CSL **WILL** be needed for e.g. door locks on batteries, where sleeping all the time - yet - having a sub-second response is desired. But... this is un-achievable with esp32 as it does not have SRAM-preserving deep sleep; achoevable with the nRF52 though.)

- 1.3 and 1.4 really do not have features for a regular MTD/FTD device like ours. They are more about Border Routers (see also below the answer by Opus)

===

Putting aside CSL from which we can and do opt-out even if we claim to support Thread 1.2+, the _one_ _single_ implementation detail this PR needs to implement is support for the so called "alternate short addr". In a nutshell:
- Only relevant for FTD
- Only if the FTD is elected as a Router
- Only relevant for the ~ 8s during which the device transitions from Child to Router, so that the device can still be reached on its old short addr

Now, the `EspRadio` does not (yet) have the alternate short addr filtering exposed, even if the underlying 802.15.4 hardware supports it (ESP-IDF has it exposed already). But we can add this later, and in the meantime - Opus is trying to convince me that just "skipping" the alt addr for those 8 seconds is not the end of the world: "the alt-RLOC16 is a reliability optimization (`radio.h:565`): peers relearn the new RLOC16 within the ~8s window; retransmit covers the gap;".

===

To cover the whole story though we now have a way to elect ourselves as a Router, and also a `become_router.rs` example, which works.
