### PR TITLE
Report OpenThread's default receive sensitivity instead of 0 dBm

### DIFF
--- a/openthread/CHANGELOG.md
+++ b/openthread/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Fix FTD Routers silently dropping mesh-local unicasts (#106)
+  * Report OpenThread's default receive sensitivity (-110 dBm) instead of 0 dBm as the noise floor for link-quality grading
 * Advertise **Thread 1.4** instead of Thread 1.1 (#103)
   * The stack now reports Thread version 1.4. Note that Thread 1.3+ is the floor Matter-over-Thread expects; for a plain node (no Border Router, no TREL) the on-air/radio contract is unchanged past 1.2, so this is effectively a version bump plus a few benign internal behaviors (e.g. a more thorough parent search at attach).
   * CSL is deliberately **not** compiled in: both `OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE` (which otherwise defaults on at >= 1.2) and `OT_CSL_RECEIVER` are forced off. This keeps the radio-platform contract identical to 1.1 — no `EnableCsl` / `ReceiveAt` / `GetCslAccuracy` callbacks are referenced — so every existing `Radio` driver keeps working unchanged. Low-power CSL (SSED) remains a future opt-in.

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -2607,9 +2607,10 @@ impl<'a> OtContext<'a> {
         rssi
     }
 
-    // from https://github.com/espressif/esp-idf/blob/release/v5.3/components/openthread/src/port/esp_openthread_radio.c#L35
-    fn plat_radio_receive_sensititivy(&mut self) -> i8 {
-        let sens = 0; // TODO
+    fn plat_radio_receive_sensitivity(&mut self) -> i8 {
+        // The C stack's `kDefaultReceiveSensitivity` (`radio/radio.hpp`) as the
+        // noise floor for grading neighbors, until drivers can report real figures.
+        let sens = -110;
         trace!(
             "Plat radio receive sensitivity callback, sensitivity: {}",
             sens

--- a/openthread/src/platform.rs
+++ b/openthread/src/platform.rs
@@ -112,7 +112,7 @@ extern "C" fn otPlatRadioGetRssi(instance: *const otInstance) -> i8 {
 
 #[no_mangle]
 extern "C" fn otPlatRadioGetReceiveSensitivity(instance: *const otInstance) -> i8 {
-    OtContext::callback(instance).plat_radio_receive_sensititivy()
+    OtContext::callback(instance).plat_radio_receive_sensitivity()
 }
 
 #[no_mangle]


### PR DESCRIPTION
Issue:

I was having trouble with mesh-local unicasts getting dropped after a
node promoted to Router. On investigation, I found
`OtContext::plat_radio_receive_sensitivity` returns 0 dBm.

That value threads through:

- `Radio::GetReceiveSensitivity()`                radio.hpp:903
- `SubMac::GetNoiseFloor()`                       sub_mac.cpp:702
- `LinkQualityInfo::GetLinkMargin()`              link_quality.cpp:162
- `ComputeLinkMargin(floor, rss)`                 link_quality.cpp:177
- `LinkQualityInfo::CalculateLinkQuality()`       link_quality.cpp:247
- `CostForLinkQuality(0)` = `kMaxRouteCost`         link_quality.hpp:228
- `RouterTable::GetNextHopAndPathCost()`          router_table.cpp:392
- `MeshForwarder::IsReachable()`                  mesh_forwarder_ftd.cpp:524
- `UpdateIp6RouteFtd` -> `kErrorNoRoute`            mesh_forwarder_ftd.cpp:450

`ComputeLinkMargin` returns `max(0, rssi - floor)`, setting every
neighbor's link margin to 0. This results in `CostForLinkQuality(0)` and
the Router unable to find a next hop. Confusingly, the router raises
`kErrorNoRoute` while `otUdpSend` reports success.

Fix:

Return `kDefaultReceiveSensitivity` (-110 dBm, `radio/radio.hpp`).

This uses the C stack's fallback value when there is no radio, and it's
also aliased as `kDefaultNoiseFloor` (`mac_links.hpp`).

Validation:

Issue started on my nRF52833 FTD mesh; after promotion from Child,
all mesh-local communication stopped. With the change, communication
continued after promotion.

Notes:

I included a changelog entry as I wasn't sure about the protocol.
I'm happy to modify or delete that at your preference.
