### PR TITLE
Convert the nRF radio's LQI energy reading to an RSSI in dBm

### DIFF
--- a/openthread/CHANGELOG.md
+++ b/openthread/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* `NrfRadio`: convert the LQI energy reading into RSSI dBm according to nRF Product Specifications (#108)
 * Fix FTD Routers silently dropping mesh-local unicasts (#106)
   * Report OpenThread's default receive sensitivity (-110 dBm) instead of 0 dBm as the noise floor for link-quality grading
 * Advertise **Thread 1.4** instead of Thread 1.1 (#103)

--- a/openthread/src/radio/nrf.rs
+++ b/openthread/src/radio/nrf.rs
@@ -139,6 +139,10 @@ impl Radio for NrfRadio<'_> {
     async fn receive(&mut self, psdu_buf: &mut [u8]) -> Result<PsduMeta, Self::Error> {
         trace!("NRF Radio, about to receive");
 
+        // `ED_RSSIOFFS`, offset for converting the radio's LQI energy reading to dBm.
+        // nRF52/53/54 Product Specifications report -92 or -93.
+        const ED_RSSI_OFFSET: i8 = -93;
+
         let channel = self.config.channel;
 
         loop {
@@ -157,8 +161,7 @@ impl Radio for NrfRadio<'_> {
 
             trace!("NRF Radio, received: {}", Bytes(&psdu_buf[..len]));
 
-            let lqi = packet.lqi();
-            let rssi = lqi as _; // TODO: Convert LQI to RSSI
+            let rssi = ED_RSSI_OFFSET.saturating_add_unsigned(packet.lqi());
 
             break Ok(PsduMeta {
                 // TODO: `embassy-nrf` driver provides the PSDU without the CRC,


### PR DESCRIPTION
Issue:

`NrfRadio::receive` reports `packet.lqi()` directly as the frame's
RSSI:

```rust
  let lqi = packet.lqi();
  let rssi = lqi as _; // TODO: Convert LQI to RSSI
```

Change:

Across all available Product Specifications, the conversion from the
LQI energy reading to dBm is given as the following (with one exception):

  `P_RF[dBm] = ED_RSSIOFFS + VAL_HARDWARE`

where `VAL_HARDWARE` corresponds to `embassy-nrf`s [`Packet::lqi`](https://docs.embassy.dev/embassy-nrf/0.10.0/nrf52840/radio/ieee802154/struct.Packet.html#method.lqi).

The exception is the nRF52840 PS which includes a scaling term:

  `P_RF[dBm] = ED_RSSIOFFS + ED_RSSISCALE x VAL_HARDWARE`

That scaling term is used in other PSs to scale the value into
"`802.15.4 units`". Working through the math in the nRF52840 PS
indicates that is true here as well.

Assuming the max 802.15.4 value of 255 from the scaled hardware
reading, the equation yields an unbelievable value:

  `P_RF[dBm] = ED_RSSIOFFS + ED_RSSISCALE x VAL_HARDWARE`
  `P_RF[dBm] = -92 + 255 = +163 dBm`

Using the equation shared by all other PSs and assuming
`ED_RSSISCALE` is a scaling factor for 802.15.4 units:

  `P_RF[802.15.4 units] = MIN( ED_RSSISCALE x VAL_HARDWARE, 255 )`

  `P_RF[dBm] = ED_RSSIOFFS + 802.15.4_MAX / ED_RSSISCALE`
  `P_RF[dBm] = -92 + 255 / 4 = -28 dBm`

`ED_RSSIOFFS` is chip-specific, but only two values across the seven
thread-capable Product Specifications that publish one:

- `-92`
  - nRF52811
  - nRF52840
  - nRF54L05 | nRF54L10 |nRF54L15
  - nRF54LM20A | nRF54LM20B
- `-93`
  - nRF52820
  - nRF52833
  - nRF5340

I went with `-93` to be conservative but can change it to `-92` if you'd
prefer to favor the 52840 and newer parts.

The conversion became:

```rust
  const ED_RSSI_OFFSET: i8 = -93;
  ...
  let rssi = ED_RSSI_OFFSET.saturating_add_unsigned(packet.lqi());
```
