### PR TITLE
Console fixes

### DIFF
--- a/tests/esp/src/bin/cli_node.rs
+++ b/tests/esp/src/bin/cli_node.rs
@@ -171,9 +171,18 @@ async fn run_cli(ot: OpenThread<'static>, mut console_rx: ConsoleRx) -> ! {
                 let line = reader.line().trim();
 
                 match line {
-                    "reset" => esp_hal::system::software_reset(),
+                    // Drain before rebooting, or the reply races the reset:
+                    // whether it reaches the wire comes down to timing, and
+                    // the harness is left waiting on a response that was
+                    // never sent - which it reports as a device that went
+                    // quiet, a long way from the cause.
+                    "reset" => {
+                        console::drained().await;
+                        esp_hal::system::software_reset()
+                    }
                     "factoryreset" => {
                         let _ = ot.cli_input_line(line);
+                        console::drained().await;
                         esp_hal::system::software_reset();
                     }
                     "" => (),
@@ -210,8 +219,13 @@ async fn run_console_out(mut console_tx: ConsoleTx) -> ! {
 
     loop {
         let len = console::read_out(&mut buf).await;
+        // No await between taking the bytes and claiming them - see `tx_begin`.
+        console::tx_begin();
+
         let _ = console_tx.write_all(&buf[..len]).await;
         let _ = console_tx.flush().await;
+
+        console::tx_end();
     }
 }
 

--- a/tests/nrf/Cargo.toml
+++ b/tests/nrf/Cargo.toml
@@ -40,6 +40,11 @@ uf2 = []
 # nRF52840 or an nRF52840 dongle - and wrong for one where the host talks to a
 # UART-to-USB bridge, like the DK's J-Link VCOM.
 console-usb = ["dep:embassy-usb"]
+# Which pins the UART console comes out on. The default is the DK's J-Link
+# virtual COM port (P0.06 TX, P0.08 RX); this selects a XIAO nRF52840's D6/D7
+# pads (P1.11 TX, P1.12 RX) instead, which is what a XIAO wired to an external
+# debug probe's UART bridge needs. Ignored under `console-usb`.
+console-uart-xiao = []
 
 [dependencies]
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }

--- a/tests/nrf/src/bin/cli_node.rs
+++ b/tests/nrf/src/bin/cli_node.rs
@@ -39,13 +39,15 @@ use cortex_m_rt::entry;
 
 use embassy_executor::{Executor, InterruptExecutor, Spawner};
 
+#[cfg(not(feature = "console-usb"))]
+use embassy_nrf::buffered_uarte::{BufferedUarte, BufferedUarteRx, BufferedUarteTx};
 use embassy_nrf::interrupt::{InterruptExt, Priority};
 use embassy_nrf::mode::Blocking;
 use embassy_nrf::nvmc::Nvmc;
 use embassy_nrf::radio::ieee802154::Radio as Ieee802154;
 use embassy_nrf::rng::Rng;
 #[cfg(not(feature = "console-usb"))]
-use embassy_nrf::uarte::{self, UarteRx, UarteTx};
+use embassy_nrf::uarte;
 #[cfg(feature = "console-usb")]
 use embassy_nrf::usb;
 use embassy_nrf::{bind_interrupts, interrupt, peripherals, radio};
@@ -85,7 +87,7 @@ macro_rules! mk_static {
 #[cfg(not(feature = "console-usb"))]
 bind_interrupts!(struct Irqs {
     RADIO => radio::InterruptHandler<peripherals::RADIO>;
-    UARTE0 => uarte::InterruptHandler<peripherals::UARTE0>;
+    UARTE0 => embassy_nrf::buffered_uarte::InterruptHandler<peripherals::UARTE0>;
 });
 
 #[cfg(feature = "console-usb")]
@@ -97,9 +99,9 @@ bind_interrupts!(struct Irqs {
 
 /// The console's two ends, whichever peripheral is underneath.
 #[cfg(not(feature = "console-usb"))]
-type ConsoleTx = UarteTx<'static>;
+type ConsoleTx = BufferedUarteTx<'static>;
 #[cfg(not(feature = "console-usb"))]
-type ConsoleRx = UarteRx<'static>;
+type ConsoleRx = BufferedUarteRx<'static>;
 
 #[cfg(feature = "console-usb")]
 type UsbDriver = usb::Driver<'static, usb::vbus_detect::HardwareVbusDetect>;
@@ -138,11 +140,39 @@ fn main() -> ! {
     #[cfg(not(feature = "console-usb"))]
     let (console_tx, console_rx) = {
         let mut uarte_config = uarte::Config::default();
-        uarte_config.baudrate = uarte::Baudrate::BAUD115200;
-        uarte_config.parity = uarte::Parity::EXCLUDED;
+        uarte_config.baudrate = uarte::Baudrate::Baud115200;
+        uarte_config.parity = uarte::Parity::Excluded;
 
-        // The DK's J-Link virtual COM port.
-        uarte::Uarte::new(p.UARTE0, p.P0_08, p.P0_06, Irqs, uarte_config).split()
+        // The DK's J-Link virtual COM port by default; `console-uart-xiao`
+        // picks a XIAO nRF52840's D6/D7 pads instead, for a XIAO wired to an
+        // external debug probe's UART bridge.
+        #[cfg(not(feature = "console-uart-xiao"))]
+        let (rxd, txd) = (p.P0_08, p.P0_06);
+        #[cfg(feature = "console-uart-xiao")]
+        let (rxd, txd) = (p.P1_12, p.P1_11);
+
+        // Buffered rather than a raw `Uarte`: a raw `UarteRx::read` only arms
+        // EasyDMA for the duration of the call, so a byte arriving while the
+        // node echoes the previous one is lost, and the harness sees commands
+        // mangled into `InvalidCommand`. The buffered driver keeps RX armed
+        // into a ring buffer. Its TIMER, PPI channels and PPI group are free
+        // here: this node drives the radio through `embassy-nrf` alone, with
+        // no MPSL and no Nordic C driver bidding for them.
+        let (console_rx, console_tx) = BufferedUarte::new(
+            p.UARTE0,
+            p.TIMER1,
+            p.PPI_CH0,
+            p.PPI_CH1,
+            p.PPI_GROUP3,
+            rxd,
+            txd,
+            Irqs,
+            uarte_config,
+            mk_static!([u8; 1024], [0; 1024]),
+            mk_static!([u8; 1024], [0; 1024]),
+        )
+        .split();
+        (console_tx, console_rx)
     };
 
     #[cfg(feature = "console-usb")]
@@ -227,7 +257,7 @@ async fn run_cli(ot: OpenThread<'static>, mut console_rx: ConsoleRx) -> ! {
 
     loop {
         #[cfg(not(feature = "console-usb"))]
-        let read = console_rx.read(&mut buf[..1]).await.map(|()| 1);
+        let read = console_rx.read(&mut buf).await;
         #[cfg(feature = "console-usb")]
         let read = {
             console_rx.wait_connection().await;
@@ -243,9 +273,18 @@ async fn run_cli(ot: OpenThread<'static>, mut console_rx: ConsoleRx) -> ! {
                 let line = reader.line().trim();
 
                 match line {
-                    "reset" => cortex_m::peripheral::SCB::sys_reset(),
+                    // Drain before rebooting, or the reply races the reset:
+                    // whether it reaches the wire comes down to timing, and
+                    // the harness is left waiting on a response that was
+                    // never sent - which it reports as a device that went
+                    // quiet, a long way from the cause.
+                    "reset" => {
+                        console::drained().await;
+                        cortex_m::peripheral::SCB::sys_reset()
+                    }
                     "factoryreset" => {
                         let _ = ot.cli_input_line(line);
+                        console::drained().await;
                         cortex_m::peripheral::SCB::sys_reset();
                     }
                     "" => (),
@@ -294,6 +333,8 @@ async fn run_console_out(mut console_tx: ConsoleTx) -> ! {
         console_tx.wait_connection().await;
 
         let len = console::read_out(&mut buf).await;
+        // No await between taking the bytes and claiming them - see `tx_begin`.
+        console::tx_begin();
 
         #[cfg(not(feature = "console-usb"))]
         let _ = console_tx.write(&buf[..len]).await;
@@ -335,6 +376,8 @@ async fn run_console_out(mut console_tx: ConsoleTx) -> ! {
                 let _ = embassy_time::with_timeout(TX_STALL, console_tx.write_packet(&[])).await;
             }
         }
+
+        console::tx_end();
     }
 }
 

--- a/tests/shared/console.rs
+++ b/tests/shared/console.rs
@@ -30,6 +30,8 @@
 //! truncated line far more usefully than it reports a node that stopped
 //! breathing.
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pipe::Pipe;
 
@@ -66,7 +68,30 @@ pub async fn read_out(buf: &mut [u8]) -> usize {
     OUT.read(buf).await
 }
 
-/// Wait until every byte queued so far has been taken by the console task.
+/// Whether the console task is holding bytes it has taken from [`OUT`] but
+/// not yet put on the wire.
+///
+/// An empty pipe is not the same as an empty wire: the task takes a chunk and
+/// only then writes it. Reset paths care about the difference, because a chip
+/// reset that beats the last write truncates the very reply the harness is
+/// waiting for.
+static TX_INFLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// Claim the bytes just taken from [`OUT`] as in flight.
+///
+/// Must be called by the console task with no await between it and the
+/// [`read_out`] that produced the bytes - on a single-threaded executor that
+/// is what makes the hand-off atomic with respect to [`drained`].
+pub fn tx_begin() {
+    TX_INFLIGHT.store(true, Ordering::Release);
+}
+
+/// Release the claim once the bytes are on the wire.
+pub fn tx_end() {
+    TX_INFLIGHT.store(false, Ordering::Release);
+}
+
+/// Wait until every byte queued so far has reached the wire.
 ///
 /// The command loop awaits this after each CLI command, BEFORE reading the
 /// next one: the harness is strictly command-response paced, so parking here
@@ -74,7 +99,7 @@ pub async fn read_out(buf: &mut [u8]) -> usize {
 /// wire - cooperative backpressure that makes command/response traffic
 /// lossless without ever blocking the (synchronous) output callback.
 pub async fn drained() {
-    while !OUT.is_empty() {
+    while !OUT.is_empty() || TX_INFLIGHT.load(Ordering::Acquire) {
         // The drain task is the one emptying the pipe; yielding is what lets
         // it run. `yield_now` alone can spin ahead of a slow wire, so pace it
         // with the smallest real delay.
@@ -89,18 +114,30 @@ pub async fn drained() {
 /// reads - which is also what a person on a serial console expects.
 pub struct LineReader {
     line: heapless::Vec<u8, LINE_MAX>,
+    /// Whether the previous byte was a CR, so that the LF of a CRLF pair is
+    /// swallowed rather than taken as a second, empty line.
+    after_cr: bool,
 }
 
 impl LineReader {
     pub const fn new() -> Self {
         Self {
             line: heapless::Vec::new(),
+            after_cr: false,
         }
     }
 
     /// Feed one received byte; returns whether it completed a line.
+    ///
+    /// CR, LF and CRLF all end a line - but CRLF ends *one*, not two. Taking
+    /// the LF as a second (empty) line would answer a single command with two
+    /// prompts, and whoever is matching prompts on the other end then reads one
+    /// command behind for the rest of the session.
     pub fn push(&mut self, byte: u8) -> bool {
+        let after_cr = core::mem::replace(&mut self.after_cr, byte == b'\r');
+
         match byte {
+            b'\n' if after_cr => false,
             b'\r' | b'\n' => {
                 out(b"\r\n");
                 true

--- a/tests/src/bin/serial_bridge.rs
+++ b/tests/src/bin/serial_bridge.rs
@@ -85,6 +85,18 @@ const DEFAULT_RESET_CMD: &str = "factoryreset";
 /// problem better than we can).
 const PROMPT_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// How quiet the line must go before the bridge trusts it enough to write.
+const SETTLE_QUIET: Duration = Duration::from_millis(50);
+
+/// How long to spend waiting for that quiet before writing anyway.
+const SETTLE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// How many times to send the reset before falling back to waiting it out.
+const RESET_ATTEMPTS: usize = 3;
+
+/// How long each of those attempts waits for the prompt.
+const RESET_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// How long a vanished device gets to re-enumerate before the bridge gives
 /// up and exits. Covers a chip reset plus USB re-enumeration with a wide
 /// margin; a device still gone after this is not rebooting, it is dead.
@@ -351,10 +363,94 @@ fn pump(mut device: Device) -> ! {
 /// expects a prompt within a tenth of a second of spawning us, and a device
 /// that has merely been sitting idle will not volunteer one - so something has
 /// to prod it.
+/// Read until the device shows a prompt, or `timeout` expires.
+fn await_prompt(device: &mut Device, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    let mut seen = Vec::new();
+    let mut buf = [0; 256];
+
+    while Instant::now() < deadline {
+        match device.read(&mut buf) {
+            Some(n) => {
+                seen.extend_from_slice(&buf[..n]);
+
+                if seen.ends_with(b"> ") {
+                    return true;
+                }
+
+                if seen.len() > 8192 {
+                    seen.drain(..seen.len() - 2);
+                }
+            }
+            None => {
+                if device.take_reconnected() {
+                    return true;
+                }
+
+                wait(
+                    &device.fd,
+                    PollFlags::POLLIN,
+                    Some(Duration::from_millis(50)),
+                );
+            }
+        }
+    }
+
+    false
+}
+
+fn settle(device: &mut Device) {
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    let mut quiet_since = Instant::now();
+    let mut buf = [0; 256];
+
+    while Instant::now() < deadline {
+        match device.read(&mut buf) {
+            Some(_) => quiet_since = Instant::now(),
+            None => {
+                if quiet_since.elapsed() >= SETTLE_QUIET {
+                    return;
+                }
+
+                wait(
+                    &device.fd,
+                    PollFlags::POLLIN,
+                    Some(Duration::from_millis(10)),
+                );
+            }
+        }
+    }
+}
+
 fn reset_device(device: &mut Device) {
     let command = std::env::var(RESET_VAR).unwrap_or_else(|_| DEFAULT_RESET_CMD.to_string());
 
-    device.write(format!("{command}\r\n").as_bytes());
+    // Let the line settle before the first write, discarding whatever opening
+    // it stirred up. A USB-serial bridge chip generally (re)configures its UART
+    // when the host opens the port, and that transient reads as framing errors
+    // on both sides - on a XIAO nRF54L15's onboard SAMD11 it corrupts the first
+    // bytes in each direction. Writing the reset into that window loses it, and
+    // the run then proceeds against a device that never reset: stale dataset,
+    // stale role, and tests failing a long way from the cause.
+    settle(device);
+
+    // Retry the reset rather than trusting it to land first time. The first
+    // exchange after an open is the least reliable one there is - see `settle`
+    // - and a lost reset does not fail loudly: the device simply keeps the
+    // previous test's state, so the next test configures a node that is still
+    // running Thread, `extaddr` comes back `InvalidState`, and the failure
+    // surfaces later as a node that never becomes leader. An empty line first,
+    // to flush any half-line the transient left in the device's reader.
+    for attempt in 0..RESET_ATTEMPTS {
+        device.write(b"\r\n");
+        device.write(format!("{command}\r\n").as_bytes());
+
+        if await_prompt(device, RESET_ATTEMPT_TIMEOUT) {
+            return;
+        }
+
+        let _ = attempt;
+    }
 
     // Read until the prompt reappears, discarding the reset's own banner - the
     // harness has not started listening yet, and a boot banner in its stream


### PR DESCRIPTION
A set of small fixes to make the NRF console of the `cli_node` test driver more reliable and convenient:
* Use buffered UART as opposed to raw UART
* Count CRLF as one line terminator
* Drain the console after every test
* Retry the `serial_bridge`'s opening `factoryreset` or else the next test in the sequence might fail because the device is in an inconsistent state

Also, implement a new UART-pins' selector feature - `console-uart-xiao` - so that the console can either be used with the XIAO board or with the NRF-802154 DK board.