### PR TITLE
Remove portable-atomic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ async-io = { version = "2", default-features = false }
 nix = { version = "0.30", default-features = false }
 esp-radio = { version = "1.0.0-beta.0", default-features = false }
 embassy-nrf = { version = "0.11", default-features = false }
-portable-atomic = { version = "1", default-features = false }
 
 mbedtls-rs-sys = { version = "0.2", default-features = false }
 openthread-sys = { version = "0.3", path = "openthread-sys", default-features = false }

--- a/openthread/CHANGELOG.md
+++ b/openthread/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Remove the `portable-atomic` dependency
+
 ## [0.3.0] - 2026-08-20
 * (Breaking) Changes to the Radio trait to fill in functionality gaps, fix bugs and bring more clarity (#109)
   * `PsduMeta` extended with an `lqi` field

--- a/openthread/Cargo.toml
+++ b/openthread/Cargo.toml
@@ -168,4 +168,3 @@ async-io = { workspace = true, default-features = false, optional = true }
 nix = { workspace = true, default-features = false, features = ["fs", "term", "poll"], optional = true }
 esp-radio = { workspace = true, default-features = false, features = ["unstable", "ieee802154"], optional = true }
 embassy-nrf = { workspace = true, default-features = false, optional = true }
-portable-atomic = { workspace = true, default-features = false }

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -21,7 +21,6 @@ use embassy_time::Instant;
 
 use fmt::Bytes;
 use openthread_sys::otTaskletsArePending;
-use portable_atomic::Ordering;
 
 use platform::{OT_ACTIVE_STATE, OT_REFCNT};
 
@@ -174,10 +173,17 @@ impl<'a> OpenThread<'a> {
         settings: &'a mut dyn Settings,
         resources: &'a mut OtResources,
     ) -> Result<Self, OtError> {
-        if OT_REFCNT
-            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
+        let acquired = OT_REFCNT.lock(|refcnt| {
+            let acquired = refcnt.get() == 0;
+
+            if acquired {
+                refcnt.set(1);
+            }
+
+            acquired
+        });
+
+        if !acquired {
             // `OpenThread` is already instantiated; can't instantiate another instance
             // until all `OpenThread` instances are dropped
             Err(OtError::new(otError_OT_ERROR_NO_BUFS))?;
@@ -1800,7 +1806,7 @@ impl<'a> OpenThread<'a> {
 
 impl Drop for OpenThread<'_> {
     fn drop(&mut self) {
-        if OT_REFCNT.load(Ordering::SeqCst) == 1 {
+        if OT_REFCNT.lock(|refcnt| refcnt.get()) == 1 {
             // We are the last clone of `OpenThread` so we should finalize the OpenThread instance
 
             let mut ot = self.activate();
@@ -1811,14 +1817,14 @@ impl Drop for OpenThread<'_> {
         }
 
         // Decrement the reference count
-        OT_REFCNT.fetch_sub(1, Ordering::SeqCst);
+        OT_REFCNT.lock(|refcnt| refcnt.set(refcnt.get() - 1));
     }
 }
 
 impl Clone for OpenThread<'_> {
     fn clone(&self) -> Self {
         // Increment the reference count
-        OT_REFCNT.fetch_add(1, Ordering::SeqCst);
+        OT_REFCNT.lock(|refcnt| refcnt.set(refcnt.get() + 1));
 
         Self {
             state: self.state,

--- a/openthread/src/platform.rs
+++ b/openthread/src/platform.rs
@@ -1,9 +1,10 @@
 //! An internal module that does the plumbing from the OpenThread C "Platform" API callbacks to Rust
 
-use core::cell::UnsafeCell;
+use core::cell::{Cell, UnsafeCell};
 use core::ffi::{c_char, CStr};
 
-use portable_atomic::AtomicUsize;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
 
 use openthread_sys::otError_OT_ERROR_NONE;
 
@@ -17,7 +18,7 @@ pub(crate) struct SyncUnsafeCell<T>(pub UnsafeCell<T>);
 unsafe impl<T> Sync for SyncUnsafeCell<T> {}
 
 /// A global reference counter for OpenThread instances
-pub(crate) static OT_REFCNT: AtomicUsize = AtomicUsize::new(0);
+pub(crate) static OT_REFCNT: Mutex<CriticalSectionRawMutex, Cell<usize>> = Mutex::new(Cell::new(0));
 
 /// A static, mutable global state that allows OpenThnread to call us back via its `otPlat*` functions
 /// Look at `OtActiveState` and `OpenThread` for more information as to when this variable is set and unset
@@ -298,16 +299,16 @@ extern "C" fn otPlatRadioClearSrcMatchExtEntries(instance: *const otInstance) {
 // The exact minimal surface the upstream simulation platform provides -
 // a mode flag, plus no-op acknowledgments of the channel/power hints and of the received-frame extension hook.
 
-static DIAG_MODE: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
+static DIAG_MODE: Mutex<CriticalSectionRawMutex, Cell<bool>> = Mutex::new(Cell::new(false));
 
 #[no_mangle]
 extern "C" fn otPlatDiagModeSet(mode: bool) {
-    DIAG_MODE.store(mode, core::sync::atomic::Ordering::Relaxed);
+    DIAG_MODE.lock(|mode_cell| mode_cell.set(mode));
 }
 
 #[no_mangle]
 extern "C" fn otPlatDiagModeGet() -> bool {
-    DIAG_MODE.load(core::sync::atomic::Ordering::Relaxed)
+    DIAG_MODE.lock(|mode_cell| mode_cell.get())
 }
 
 #[no_mangle]


### PR DESCRIPTION
The crate is really only used at a handful of places.

Otherwise, the core of `openthread` - along with its non-optional dependencies - is atomics free, just like `mbedtls-rs` and `rs-matter`.