### PR TITLE
Make `run` cooperative: yield between tasklet rounds and RX frames

### DIFF
--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -16,6 +16,7 @@ use core::pin::pin;
 use core::ptr::addr_of_mut;
 
 use embassy_futures::select::{select, select3, Either, Either3};
+use embassy_futures::yield_now;
 
 use embassy_time::Instant;
 
@@ -1280,9 +1281,9 @@ impl<'a> OpenThread<'a> {
                             let mut ot = self.activate();
 
                             unsafe { otPlatAlarmMilliFired(ot.state().ot.instance) };
-
-                            ot.process_tasklets();
                         }
+
+                        self.process_tasklets().await;
 
                         break;
                     }
@@ -1343,7 +1344,7 @@ impl<'a> OpenThread<'a> {
         }
 
         loop {
-            self.activate().process_tasklets();
+            self.process_tasklets().await;
 
             let rx_channel = {
                 let mut activated = self.activate();
@@ -1439,7 +1440,15 @@ impl<'a> OpenThread<'a> {
         unwrap_dbg!(radio.set_receive(channel).await);
 
         loop {
-            self.activate().process_tasklets();
+            // One frame per poll. `Radio::receive` returns without ever awaiting
+            // whenever the driver already holds a queued frame (`EspRadio`
+            // buffers 50 by default), so without this yield the loop drains a
+            // backlog frame after frame -- each with a full tasklet cascade --
+            // inside a single poll of `run`, starving every other task on the
+            // executor for the length of the whole backlog.
+            yield_now().await;
+
+            self.process_tasklets().await;
 
             let result = radio.receive(psdu_buf).await;
 
@@ -1697,13 +1706,40 @@ impl<'a> OpenThread<'a> {
         cmd.await
     }
 
+    /// Drain the OpenThread tasklet queue, yielding to the executor between rounds.
+    ///
+    /// One round is one `otTaskletsProcess` call -- see
+    /// [`OtContext::process_tasklets_round`] for why that is the natural unit.
+    /// Yielding between rounds is what keeps [`OpenThread::run`] a cooperative
+    /// future: without it a cascade of tasklets (an MLE exchange, a network-data
+    /// update, a MeshCoP handshake) runs to completion inside a single poll, and
+    /// every other task on the executor waits for the whole cascade rather than
+    /// for one round.
+    ///
+    /// The yield is a plain `yield_now`, so this task is re-queued immediately --
+    /// no work is deferred and no tasklet is delayed by more than one pass of the
+    /// executor's run queue. What changes is only that the pass happens at all.
+    async fn process_tasklets(&self) {
+        loop {
+            // Scoped so the activation guard is dropped before the yield below:
+            // `OtContext` must never be held across an await point.
+            let more = { self.activate().process_tasklets_round() };
+
+            if !more {
+                break;
+            }
+
+            yield_now().await;
+        }
+    }
+
     /// Spins the OpenThread C library loop by processing tasklets if they are pending
     /// or otherwise waiting until notified that there are pending tasklets
     async fn run_tasklets(&self) -> ! {
         loop {
             trace!("About to process Openthread tasklets");
 
-            self.activate().process_tasklets();
+            self.process_tasklets().await;
 
             poll_fn(move |cx| self.activate().state().ot.tasklets.poll_wait(cx)).await;
         }
@@ -2509,17 +2545,35 @@ impl<'a> OtContext<'a> {
         }
     }
 
-    /// Process all pending tasklets.
+    /// Process ONE round of pending tasklets.
     ///
-    /// Loops until no more tasklets are pending, matching the standard
-    /// OpenThread event loop pattern where `otTaskletsProcess` is called
-    /// repeatedly until all deferred work is completed.
-    fn process_tasklets(&mut self) {
+    /// Returns `true` if tasklets are still pending afterwards, i.e. the caller
+    /// should come back for another round.
+    ///
+    /// A "round" is what `otTaskletsProcess` is itself defined to do:
+    /// `Tasklet::Scheduler::ProcessQueuedTasklets` takes the queue as it stands
+    /// on entry, clears it, and runs exactly those tasklets. A tasklet posted
+    /// while the round runs lands on a fresh queue and re-raises
+    /// `otPlatTaskletsSignalPending`. So a round is the unit of work OpenThread
+    /// hands back to the platform, and the platform is expected to come back for
+    /// the next one -- the canonical OpenThread main loop is
+    /// `otTaskletsProcess(); otSysProcessDrivers();`, not
+    /// `while (pending) otTaskletsProcess();`.
+    ///
+    /// This is deliberately NOT a `while pending` loop. Draining every round
+    /// back-to-back makes a single poll of [`OpenThread::run`] as long as the
+    /// whole cascade -- measured at p50 363 us / max 26886 us on an ESP32-C6
+    /// carrying Thread traffic -- which starves every other task on the same
+    /// executor for that whole time. See [`OpenThread::process_tasklets`] for
+    /// the yielding loop that replaces it.
+    fn process_tasklets_round(&mut self) -> bool {
         let instance = self.state().ot.instance;
 
-        while unsafe { otTaskletsArePending(instance) } {
+        if unsafe { otTaskletsArePending(instance) } {
             unsafe { otTaskletsProcess(instance) };
         }
+
+        unsafe { otTaskletsArePending(instance) }
     }
 
     unsafe extern "C" fn plat_c_change_callback(flags: otChangedFlags, context: *mut c_void) {


### PR DESCRIPTION
`OpenThread::run` does unbounded work between poll boundaries in two places. On a single-core MCU that means every other task on the executor is starved for as long as that work takes.

Both loops below are cheap to fix and neither changes what work happens or in what order.

### 1. The tasklet drain collapses OpenThread's own cooperation point

`OtContext::process_tasklets` was:

```rust
while unsafe { otTaskletsArePending(instance) } {
    unsafe { otTaskletsProcess(instance) };
}
```

But `otTaskletsProcess` is already defined to be one bounded round — `Tasklet::Scheduler::ProcessQueuedTasklets`, in the submodule:

```cpp
// This method processes all tasklets queued when this is called. We
// keep a copy the current list and then clear the main list by
// setting `mTail` to `nullptr`. A newly posted tasklet while
// processing the currently queued tasklets will then trigger a call
// to `otTaskletsSignalPending()`.
```

Re-raising `otPlatTaskletsSignalPending` is precisely how OpenThread asks the platform to come back for the next round; the canonical main loop is `otTaskletsProcess(); otSysProcessDrivers();`. Wrapping it in `while pending` runs the entire cascade — an MLE exchange, a network-data update, a MeshCoP handshake — inside a single poll.

Split into `process_tasklets_round` (one round, reports whether more are pending) and an async `OpenThread::process_tasklets` that `yield_now()`s between rounds. All four call sites await it.

### 2. `run_radio_rx` has no suspension point of its own

The loop goes straight back into `Radio::receive`. A driver that buffers frames returns from `receive` **without ever awaiting** whenever its queue is non-empty — `EspRadio` queues 50 by default — so a backlog is drained frame after frame, each with a full `otPlatRadioReceiveDone` and tasklet cascade, inside one poll. One `yield_now()` per iteration bounds a poll to one frame; the backlog still drains, just not all at once.

### Cost

`yield_now` re-queues the task immediately, so nothing is deferred and no tasklet is delayed by more than one pass of the executor's run queue. The only change is that the pass happens at all.

Builds clean for `riscv32imac-unknown-none-elf` with `matter,ftd,defmt,isupper`; `cargo fmt` and `clippy` clean (the 7 remaining clippy warnings are pre-existing).

Happy to adjust the shape — e.g. gating the RX yield behind a feature, or exposing the round budget — if you'd rather not change the default behaviour.