### PR TITLE
Size reports

### DIFF
--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -1,0 +1,89 @@
+# Posts the size reports produced by the `Size` workflow (size.yml) as one pull request
+# comment, updating it on every push.
+#
+# Separate from `size.yml` on purpose: that workflow runs the pull request's code with a
+# read-only token, so it cannot comment on pull requests from forks. This one runs on
+# `workflow_run` in the base repository with a write token, and neither checks out nor
+# runs anything from the pull request. The reports are taken from the artifacts and only
+# ever end up inside the comment body.
+name: Size comment
+
+on:
+  workflow_run:
+    workflows: [Size]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
+
+    steps:
+      - name: Find the pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Look the pull request up by the commit the reports were built from, rather
+          # than trusting anything in the artifacts. Nothing is found when the pull
+          # request got another push meanwhile; that run will report instead.
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" \
+            --jq "[.[] | select(.head.sha == \"$HEAD_SHA\")][0] | \"\(.number) \(.base.sha)\"")
+          if [ -z "$pr" ] || [ "$pr" = "null null" ]; then
+            echo "No open pull request has $HEAD_SHA as its head; nothing to comment on"
+            exit 0
+          fi
+          echo "number=${pr% *}" >> "$GITHUB_OUTPUT"
+          echo "base=${pr#* }" >> "$GITHUB_OUTPUT"
+
+      - name: Download the size reports
+        if: steps.pr.outputs.number
+        uses: actions/download-artifact@v4
+        with:
+          pattern: size-*
+          path: size
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compose the comment
+        if: steps.pr.outputs.number
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASE_SHA: ${{ steps.pr.outputs.base }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          {
+            echo "## Size report"
+            echo "<!-- size-report -->"
+            echo
+            echo "Firmware size at ${HEAD_SHA:0:7} compared to the base branch at ${BASE_SHA:0:7}."
+            echo "Regions that grew by more than 0.2% are marked. [Workflow run]($RUN_URL)"
+            echo
+            for report in size/*.md; do
+              cat "$report"
+              echo
+            done
+          } > comment.md
+          cat comment.md
+
+      - name: Post or update the comment
+        if: steps.pr.outputs.number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- size-report -->"))][0].id')
+          if [ -n "$id" ] && [ "$id" != "null" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" -F body=@comment.md > /dev/null
+            echo "Updated comment $id on #$PR"
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -F body=@comment.md > /dev/null
+            echo "Commented on #$PR"
+          fi

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -1,11 +1,11 @@
-# Posts the size reports produced by the `Size` workflow (size.yml) as one pull request
+# Posts the size report produced by the `Size` workflow (size.yml) as a pull request
 # comment, updating it on every push.
 #
 # Separate from `size.yml` on purpose: that workflow runs the pull request's code with a
 # read-only token, so it cannot comment on pull requests from forks. This one runs on
 # `workflow_run` in the base repository with a write token, and neither checks out nor
-# runs anything from the pull request. The reports are taken from the artifacts and only
-# ever end up inside the comment body.
+# runs anything from the pull request. The report is taken from the artifact and only
+# ever ends up inside the comment body.
 name: Size comment
 
 on:
@@ -41,13 +41,12 @@ jobs:
           echo "number=${pr% *}" >> "$GITHUB_OUTPUT"
           echo "base=${pr#* }" >> "$GITHUB_OUTPUT"
 
-      - name: Download the size reports
+      - name: Download the size report
         if: steps.pr.outputs.number
         uses: actions/download-artifact@v4
         with:
-          pattern: size-*
-          path: size
-          merge-multiple: true
+          name: size-report
+          path: report
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -65,10 +64,7 @@ jobs:
             echo "Firmware size at ${HEAD_SHA:0:7} compared to the base branch at ${BASE_SHA:0:7}."
             echo "Regions that grew by more than 0.2% are marked. [Workflow run]($RUN_URL)"
             echo
-            for report in size/*.md; do
-              cat "$report"
-              echo
-            done
+            cat report/size-report.md
           } > comment.md
           cat comment.md
 

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -62,7 +62,7 @@ jobs:
             echo "<!-- size-report -->"
             echo
             echo "Firmware size at ${HEAD_SHA:0:7} compared to the base branch at ${BASE_SHA:0:7}."
-            echo "Regions that grew by more than 0.2% are marked. [Workflow run]($RUN_URL)"
+            echo "[Workflow run]($RUN_URL)"
             echo
             cat report/size-report.md
           } > comment.md

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,132 @@
+# Firmware size report for every pull request.
+#
+# One example per MCU family is built twice, at the pull request's merge commit and at the
+# tip of the base branch, and the two ELFs are diffed with `cargo elfsize`. The report goes
+# to the job summary and is uploaded as an artifact, from where the `Size comment` workflow
+# (size-comment.yml) posts it as a pull request comment. On pushes to `main` only the
+# sizes of the pushed commit are reported.
+#
+# Both builds run in the same checkout directory on purpose: panic-location strings embed
+# absolute source paths, so building the base in a second directory with a different path
+# length shifts `.rodata` by kilobytes.
+#
+# The examples are built with `force-generate-bindings`, same as in `ci.yml`, so that the
+# OpenThread C libraries reflect the pull request's `openthread-sys` configuration rather
+# than the committed prebuilt ones, which may lag behind it.
+name: Size
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A new push to a pull request supersedes the size run already in flight for it
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  # Growth above this many percent is marked in the report and annotated on the run
+  SIZE_WARN_PERCENT: "0.2"
+
+jobs:
+  size:
+    name: Size
+    runs-on: ubuntu-latest
+    permissions: read-all
+    strategy:
+      fail-fast: false
+      matrix:
+        # [family, examples feature, target, example, report label]
+        mcu:
+          - [esp, esp32c6, riscv32imac-unknown-none-elf, basic_udp, esp32c6]
+          - [esp, esp32h2, riscv32imac-unknown-none-elf, basic_udp, esp32h2]
+          - [nrf, default, thumbv7em-none-eabi, basic_udp, nrf52840]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The base commit is checked out below
+          fetch-depth: 0
+
+      - name: openthread init
+        run: git submodule update --init --recursive
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          target: x86_64-unknown-linux-gnu
+          toolchain: nightly
+          components: rust-src
+
+      - name: Install MCU target
+        run: rustup target add ${{ matrix.mcu[2] }}
+
+      - name: Detect host target triple
+        run: |
+          export HOST_TARGET=$(rustup show | grep "Default host" | sed -e 's/.* //')
+          echo "HOST_TARGET=$HOST_TARGET" >> $GITHUB_ENV
+
+      - name: Install espup
+        run: |
+          curl -LO https://github.com/esp-rs/espup/releases/latest/download/espup-${{ env.HOST_TARGET }}.zip
+          unzip -o espup-${{ env.HOST_TARGET }}.zip -d "$HOME/.cargo/bin"
+          chmod +x "$HOME/.cargo/bin/espup"*
+          echo "ESPUP_EXPORT_FILE=$HOME/exports" >> $GITHUB_ENV
+
+      - name: Install espup toolchains (xtensa and riscv)
+        if: matrix.mcu[0] == 'esp'
+        run: |
+          source "$HOME/.cargo/env"
+          "$HOME/.cargo/bin/espup" install -e -r
+          source "$HOME/exports"
+          echo "${LIBCLANG_PATH}/../bin:$PATH" >> "$GITHUB_PATH"
+          echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
+          echo "CLANG_PATH=${CLANG_PATH}" >> "$GITHUB_ENV"
+
+      # Not yet published; until then, built from the `size-check` branch of embuild
+      - name: Install cargo-elfsize
+        run: cargo install --git https://github.com/esp-rs/embuild --branch size-check cargo-elfsize
+
+      - name: Build - Head
+        run: |
+          cd examples/${{ matrix.mcu[0] }}
+          cargo build --release --no-default-features --features ${{ matrix.mcu[1] }},force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort --bin ${{ matrix.mcu[3] }}
+          cp target/${{ matrix.mcu[2] }}/release/${{ matrix.mcu[3] }} "$RUNNER_TEMP/head.elf"
+
+      - name: Check out the base commit
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout --detach ${{ github.event.pull_request.base.sha }}
+          git submodule update --init --recursive
+
+      - name: Build - Base
+        if: github.event_name == 'pull_request'
+        run: |
+          cd examples/${{ matrix.mcu[0] }}
+          cargo build --release --no-default-features --features ${{ matrix.mcu[1] }},force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort --bin ${{ matrix.mcu[3] }}
+          cp target/${{ matrix.mcu[2] }}/release/${{ matrix.mcu[3] }} "$RUNNER_TEMP/base.elf"
+
+      - name: Size report
+        run: |
+          title="${{ matrix.mcu[3] }} on ${{ matrix.mcu[4] }} (${{ matrix.mcu[2] }})"
+          if [ -f "$RUNNER_TEMP/base.elf" ]; then
+            cargo elfsize --title "$title" --warn "$SIZE_WARN_PERCENT" "$RUNNER_TEMP/base.elf" "$RUNNER_TEMP/head.elf" > "$RUNNER_TEMP/report.txt"
+          else
+            cargo elfsize --title "$title" "$RUNNER_TEMP/head.elf" > "$RUNNER_TEMP/report.txt"
+          fi
+          # Printed as-is so that the runner picks up the `::warning::` annotations;
+          # the artifact and summary get the markdown alone
+          cat "$RUNNER_TEMP/report.txt"
+          mkdir -p size
+          grep -v '^::' "$RUNNER_TEMP/report.txt" > size/${{ matrix.mcu[4] }}.md
+          cat size/${{ matrix.mcu[4] }}.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload size report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-${{ matrix.mcu[4] }}
+          path: size/
+          retention-days: 7

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -88,7 +88,6 @@ jobs:
           echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
           echo "CLANG_PATH=${CLANG_PATH}" >> "$GITHUB_ENV"
 
-      # Not yet published; until then, built from the `size-check` branch of embuild
       - name: Install elfsize
         run: cargo install elfsize
 
@@ -149,7 +148,6 @@ jobs:
         with:
           toolchain: stable
 
-      # Not yet published; until then, built from the `size-check` branch of embuild
       - name: Install elfsize
         run: cargo install elfsize
 

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -90,7 +90,7 @@ jobs:
 
       # Not yet published; until then, built from the `size-check` branch of embuild
       - name: Install cargo-elfsize
-        run: cargo install --git https://github.com/esp-rs/embuild --branch size-check cargo-elfsize
+        run: cargo install cargo-elfsize
 
       - name: Build - Head
         run: |
@@ -151,7 +151,7 @@ jobs:
 
       # Not yet published; until then, built from the `size-check` branch of embuild
       - name: Install cargo-elfsize
-        run: cargo install --git https://github.com/esp-rs/embuild --branch size-check cargo-elfsize
+        run: cargo install cargo-elfsize
 
       - name: Download the measurements
         uses: actions/download-artifact@v4

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,7 +1,7 @@
 # Firmware size report for every pull request.
 #
 # The examples of every MCU family are built twice, at the pull request's merge commit and
-# at the tip of the base branch, and the ELFs are measured with `cargo elfsize`. The
+# at the tip of the base branch, and the ELFs are measured with `elfsize`. The
 # `report` job then renders the measurements of all examples and MCUs as one report, so
 # that the same change can be compared across chips. The report goes to the job summary and is uploaded as an
 # artifact, from where the `Size comment` workflow (size-comment.yml) posts it as a pull
@@ -89,8 +89,8 @@ jobs:
           echo "CLANG_PATH=${CLANG_PATH}" >> "$GITHUB_ENV"
 
       # Not yet published; until then, built from the `size-check` branch of embuild
-      - name: Install cargo-elfsize
-        run: cargo install cargo-elfsize
+      - name: Install elfsize
+        run: cargo install elfsize
 
       - name: Build - Head
         run: |
@@ -123,13 +123,13 @@ jobs:
             label="$example on ${{ matrix.mcu[3] }}"
             out="size/$example-${{ matrix.mcu[3] }}.json"
             if [ -f "$RUNNER_TEMP/base-$example.elf" ]; then
-              cargo elfsize measure --label "$label" --output "$out" "$RUNNER_TEMP/base-$example.elf" "$RUNNER_TEMP/head-$example.elf"
+              elfsize measure --label "$label" --output "$out" "$RUNNER_TEMP/base-$example.elf" "$RUNNER_TEMP/head-$example.elf"
             else
-              cargo elfsize measure --label "$label" --output "$out" "$RUNNER_TEMP/head-$example.elf"
+              elfsize measure --label "$label" --output "$out" "$RUNNER_TEMP/head-$example.elf"
             fi
           done
           # This MCU alone, for the job summary; the annotations are left to the `report` job
-          cargo elfsize report --warn "$SIZE_WARN_PERCENT" size/*.json | grep -v '^::' >> "$GITHUB_STEP_SUMMARY"
+          elfsize report --warn "$SIZE_WARN_PERCENT" size/*.json | grep -v '^::' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload the measurement
         uses: actions/upload-artifact@v4
@@ -150,8 +150,8 @@ jobs:
           toolchain: stable
 
       # Not yet published; until then, built from the `size-check` branch of embuild
-      - name: Install cargo-elfsize
-        run: cargo install cargo-elfsize
+      - name: Install elfsize
+        run: cargo install elfsize
 
       - name: Download the measurements
         uses: actions/download-artifact@v4
@@ -162,7 +162,7 @@ jobs:
 
       - name: Report
         run: |
-          cargo elfsize report --warn "$SIZE_WARN_PERCENT" size/*.json > "$RUNNER_TEMP/report.txt"
+          elfsize report --warn "$SIZE_WARN_PERCENT" size/*.json > "$RUNNER_TEMP/report.txt"
           # Printed as-is so that the runner picks up the `::warning::` annotations;
           # the artifact and summary get the markdown alone
           cat "$RUNNER_TEMP/report.txt"

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,10 +1,11 @@
 # Firmware size report for every pull request.
 #
-# One example per MCU family is built twice, at the pull request's merge commit and at the
-# tip of the base branch, and the two ELFs are diffed with `cargo elfsize`. The report goes
-# to the job summary and is uploaded as an artifact, from where the `Size comment` workflow
-# (size-comment.yml) posts it as a pull request comment. On pushes to `main` only the
-# sizes of the pushed commit are reported.
+# The examples of every MCU family are built twice, at the pull request's merge commit and
+# at the tip of the base branch, and the ELFs are measured with `cargo elfsize`. The
+# `report` job then renders the measurements of all examples and MCUs as one report, so
+# that the same change can be compared across chips. The report goes to the job summary and is uploaded as an
+# artifact, from where the `Size comment` workflow (size-comment.yml) posts it as a pull
+# request comment. On pushes to `main` only the sizes of the pushed commit are reported.
 #
 # Both builds run in the same checkout directory on purpose: panic-location strings embed
 # absolute source paths, so building the base in a second directory with a different path
@@ -30,6 +31,8 @@ env:
   CARGO_TERM_COLOR: always
   # Growth above this many percent is marked in the report and annotated on the run
   SIZE_WARN_PERCENT: "0.2"
+  # The examples measured, present in `examples/<family>` of every family
+  SIZE_EXAMPLES: basic_enet basic_udp dns srp
 
 jobs:
   size:
@@ -39,11 +42,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # [family, examples feature, target, example, report label]
+        # [family, examples feature, target, chip label]
         mcu:
-          - [esp, esp32c6, riscv32imac-unknown-none-elf, basic_udp, esp32c6]
-          - [esp, esp32h2, riscv32imac-unknown-none-elf, basic_udp, esp32h2]
-          - [nrf, default, thumbv7em-none-eabi, basic_udp, nrf52840]
+          - [esp, esp32c6, riscv32imac-unknown-none-elf, esp32c6]
+          - [esp, esp32h2, riscv32imac-unknown-none-elf, esp32h2]
+          - [nrf, default, thumbv7em-none-eabi, nrf52840]
 
     steps:
       - uses: actions/checkout@v4
@@ -92,8 +95,10 @@ jobs:
       - name: Build - Head
         run: |
           cd examples/${{ matrix.mcu[0] }}
-          cargo build --release --no-default-features --features ${{ matrix.mcu[1] }},force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort --bin ${{ matrix.mcu[3] }}
-          cp target/${{ matrix.mcu[2] }}/release/${{ matrix.mcu[3] }} "$RUNNER_TEMP/head.elf"
+          cargo build --release --no-default-features --features ${{ matrix.mcu[1] }},force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort --bins
+          for example in $SIZE_EXAMPLES; do
+            cp target/${{ matrix.mcu[2] }}/release/$example "$RUNNER_TEMP/head-$example.elf"
+          done
 
       - name: Check out the base commit
         if: github.event_name == 'pull_request'
@@ -105,28 +110,70 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           cd examples/${{ matrix.mcu[0] }}
-          cargo build --release --no-default-features --features ${{ matrix.mcu[1] }},force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort --bin ${{ matrix.mcu[3] }}
-          cp target/${{ matrix.mcu[2] }}/release/${{ matrix.mcu[3] }} "$RUNNER_TEMP/base.elf"
+          cargo build --release --no-default-features --features ${{ matrix.mcu[1] }},force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort --bins
+          for example in $SIZE_EXAMPLES; do
+            cp target/${{ matrix.mcu[2] }}/release/$example "$RUNNER_TEMP/base-$example.elf"
+          done
 
-      - name: Size report
+      - name: Measure
         run: |
-          title="${{ matrix.mcu[3] }} on ${{ matrix.mcu[4] }} (${{ matrix.mcu[2] }})"
-          if [ -f "$RUNNER_TEMP/base.elf" ]; then
-            cargo elfsize --title "$title" --warn "$SIZE_WARN_PERCENT" "$RUNNER_TEMP/base.elf" "$RUNNER_TEMP/head.elf" > "$RUNNER_TEMP/report.txt"
-          else
-            cargo elfsize --title "$title" "$RUNNER_TEMP/head.elf" > "$RUNNER_TEMP/report.txt"
-          fi
+          mkdir -p size
+          # Named example-first so that the chips of one example end up next to each other
+          for example in $SIZE_EXAMPLES; do
+            label="$example on ${{ matrix.mcu[3] }}"
+            out="size/$example-${{ matrix.mcu[3] }}.json"
+            if [ -f "$RUNNER_TEMP/base-$example.elf" ]; then
+              cargo elfsize measure --label "$label" --output "$out" "$RUNNER_TEMP/base-$example.elf" "$RUNNER_TEMP/head-$example.elf"
+            else
+              cargo elfsize measure --label "$label" --output "$out" "$RUNNER_TEMP/head-$example.elf"
+            fi
+          done
+          # This MCU alone, for the job summary; the annotations are left to the `report` job
+          cargo elfsize report --warn "$SIZE_WARN_PERCENT" size/*.json | grep -v '^::' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the measurement
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-${{ matrix.mcu[3] }}
+          path: size/
+          retention-days: 7
+
+  report:
+    name: Report
+    runs-on: ubuntu-latest
+    needs: size
+    permissions: read-all
+
+    steps:
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      # Not yet published; until then, built from the `size-check` branch of embuild
+      - name: Install cargo-elfsize
+        run: cargo install --git https://github.com/esp-rs/embuild --branch size-check cargo-elfsize
+
+      - name: Download the measurements
+        uses: actions/download-artifact@v4
+        with:
+          pattern: size-*
+          path: size
+          merge-multiple: true
+
+      - name: Report
+        run: |
+          cargo elfsize report --warn "$SIZE_WARN_PERCENT" size/*.json > "$RUNNER_TEMP/report.txt"
           # Printed as-is so that the runner picks up the `::warning::` annotations;
           # the artifact and summary get the markdown alone
           cat "$RUNNER_TEMP/report.txt"
-          mkdir -p size
-          grep -v '^::' "$RUNNER_TEMP/report.txt" > size/${{ matrix.mcu[4] }}.md
-          cat size/${{ matrix.mcu[4] }}.md >> "$GITHUB_STEP_SUMMARY"
+          mkdir -p report
+          grep -v '^::' "$RUNNER_TEMP/report.txt" > report/size-report.md
+          cat report/size-report.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload size report
+      - name: Upload the report
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: size-${{ matrix.mcu[4] }}
-          path: size/
+          name: size-report
+          path: report/
           retention-days: 7

--- a/openthread/src/lib.rs
+++ b/openthread/src/lib.rs
@@ -1212,7 +1212,10 @@ impl<'a> OpenThread<'a> {
             // Initialize the OpenThread instance
             state.ot.instance = unsafe { otInstanceInitSingle() };
 
-            info!("OpenThread instance initialized");
+            info!(
+                "OpenThread instance initialized, version: {}",
+                Self::version()
+            );
 
             ot!(unsafe {
                 otSetStateChangedCallback(


### PR DESCRIPTION
This is inspired by the `rs-matter` (and Matter C++ SDK) size reporting which I find quite nice.
See how it looks [here](https://github.com/sysgrok/openthread/pull/5#issuecomment-5572200919).

But rather than relying on a 3K LOCs of Python code copied from Matter C++ (as `rs-matter` still does), this PR uses **a new `elfsize` command** installable with `cargo install elfsize` and maintained in the `embuild` utility.

[Here](https://github.com/esp-rs/embuild/blob/bcd6ee41f3b635d61e7888f1a43537f620e8f11b/src/elfsize.rs#L17), a comparison with `cargo size`.

#### How this differs from esp-hal's `/test-size`

(I asked Fable to compare, **let me know if something is off**.)

Same core idea (build base and head in one job, diff the ELFs, comment), with these changes:

- **Automatic and fork-safe.** Runs on every PR with a read-only token; a separate `workflow_run` job posts the comment from the base repo. No `/test-size` command, no trust list.
- **Correct baseline.** Head is the merge commit, base is `pull_request.base.sha`. esp-hal diffs against `main` HEAD at dispatch time, which picks up unrelated changes when `main` has moved.
- **Correct sections.** FLASH is the file-backed size of all `PT_LOAD` segments, i.e. the actual flash image. esp-hal's bloaty filter drops `.rodata` entirely. RAM is a section prefix list, with `.stack` excluded because esp-hal sizes it as "whatever is left".
- **One report for everything.** All examples on all chips in one comment: increases above the threshold first, then all regions and all sections collapsed. esp-hal posts one bloaty table per chip.
- **Tooling.** The [`elfsize`](https://github.com/esp-rs/embuild/tree/master/elfsize) crate from embuild, ~300 lines of Rust over `xmas-elf`, installed with `cargo install elfsize`. No bloaty action, no `llvm-tools` (which the espup Xtensa toolchain lacks).
- **Not done.** No size history across commits; each PR is measured against its own base only.