### PR TITLE
Option to build with gcc; port a few build fixes from mbedtls-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
       - name: Build
         run: cargo build
 
+      # No prebuilt libraries are committed for the host target, so this always compiles
+      # OpenThread from source -- with the system GCC rather than `clang`.
+      - name: Build - GCC
+        run: cargo build --features use-gcc
+
       - name: Fmt Check - STD Examples
         run: cd examples/std; cargo fmt -- --check
 
@@ -292,6 +297,23 @@ jobs:
           echo "${LIBCLANG_PATH}/../bin:$PATH" >> "$GITHUB_PATH"
           echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
           echo "CLANG_PATH=${CLANG_PATH}" >> "$GITHUB_ENV"
+
+      # OpenThread is C++, and on Debian/Ubuntu `newlib` and its C++ runtime are packaged apart
+      # from the compiler. The `clang` builds get by without them, on the bundled `gen/sysroot`
+      # plus `-nostdinc++`; the GCC ones do not compile without their headers.
+      - name: Install the ARM bare-metal GCC toolchain
+        if: matrix.mcu[0] == 'nrf'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+
+      # Uses the cross-toolchain installed above: `riscv32-esp-elf-gcc` for the Espressif chips,
+      # `arm-none-eabi-gcc` for the nRF one. The RISC-V one is what `force-esp-riscv-gcc`
+      # selects, in place of the "official" `riscv32-unknown-elf-gcc` that is not installed
+      # here; on the ARM entry the flag only implies `use-gcc`, as there `cc-rs` derives the
+      # compiler from the target triple, so a single invocation covers every entry.
+      - name: Build - GCC
+        run: cargo build -p openthread -p openthread-sys --features=force-generate-bindings,force-esp-riscv-gcc --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort
 
       - name: Clippy - Examples
         run: cd examples/${{ matrix.mcu[0] }}; cargo clippy --no-default-features --features ${{ matrix.mcu[1] }},force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort -- -D warnings

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -9,7 +9,9 @@
 #
 # Both builds run in the same checkout directory on purpose: panic-location strings embed
 # absolute source paths, so building the base in a second directory with a different path
-# length shifts `.rodata` by kilobytes.
+# length shifts `.rodata` by kilobytes. They therefore also share one CMake build tree,
+# which the base checkout below drops when `openthread-sys` differs between the two
+# revisions.
 #
 # The examples are built with `force-generate-bindings`, same as in `ci.yml`, so that the
 # OpenThread C libraries reflect the pull request's `openthread-sys` configuration rather
@@ -102,6 +104,17 @@ jobs:
       - name: Check out the base commit
         if: github.event_name == 'pull_request'
         run: |
+          # Both revisions build in this one directory, so they also share one CMake
+          # tree, and an `openthread-sys` change can move what `build.rs` passes to
+          # CMake. CMake answers a changed compiler by deleting its cache and re-running
+          # configure, which OpenThread's `OT_*` options do not survive -- the re-run
+          # dies on `add_subdirectory(examples/platforms/NO)`. Give the base build a
+          # clean OpenThread tree whenever `openthread-sys` differs between the two
+          # revisions; when it does not, both configure identically and the tree (with
+          # its compiled C++) is safe, and worth, keeping.
+          if ! git diff --quiet ${{ github.event.pull_request.base.sha }} -- openthread-sys; then
+            rm -rf examples/${{ matrix.mcu[0] }}/target/${{ matrix.mcu[2] }}/release/build/openthread-sys*
+          fi
           git checkout --detach ${{ github.event.pull_request.base.sha }}
           git submodule update --init --recursive
 

--- a/openthread-sys/CHANGELOG.md
+++ b/openthread-sys/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Pass the C++ driver (`<prefix>g++` / `clang++`) as `CMAKE_CXX_COMPILER` instead of the C one; OpenThread is C++, and the C driver compiles it but does not link the C++ runtime
+* Build `riscv32imafc` with the hard-float ABI (`-mabi=ilp32f`) that rustc uses for that target, in both the clang and the GCC branch
+* Honour `CLANG_PATH` when clang is the forced compiler
+* Reconfigure CMake from scratch when the compiler changed since the last build, rather than letting CMake half-reset its own cache (which loses OpenThread's `OT_*` options)
 * Update MSRV to 1.85
 
 ## [0.3.0] - 2026-08-20

--- a/openthread-sys/gen/builder.rs
+++ b/openthread-sys/gen/builder.rs
@@ -191,6 +191,15 @@ impl OpenThreadBuilder {
         let target_dir = out_path.join("openthread").join("build");
         std::fs::create_dir_all(&target_dir)?;
 
+        // Configure from scratch. CMake cannot reuse a build tree whose compiler
+        // changed: it deletes the cache mid-configure and re-runs, and
+        // OpenThread's `OT_*` options do not survive that reset -- the re-run
+        // dies on `add_subdirectory(examples/platforms/NO)`. This build script
+        // re-runs only when `gen/` or the submodule changed (see `track`), so
+        // the ordinary Rust edit loop never pays for the rebuild. `cmake-rs`
+        // configures in `<out_dir>/build`.
+        let _ = std::fs::remove_dir_all(target_dir.join("build"));
+
         let target_lib_dir = out_path.join("openthread").join("lib");
 
         let lib_dir = copy_path.unwrap_or(&target_lib_dir);
@@ -506,14 +515,19 @@ impl CMakeConfigurer {
         }
 
         if let Some((compiler, _)) = self.derive_forced_c_compiler() {
-            let mut cfg = cc::Build::new();
-            cfg.compiler(&compiler);
+            let cxx_compiler = Self::cxx_counterpart(&compiler);
+
+            let mut c_cfg = cc::Build::new();
+            c_cfg.compiler(&compiler);
+
+            let mut cxx_cfg = cc::Build::new();
+            cxx_cfg.compiler(&cxx_compiler);
 
             config
-                .init_c_cfg(cfg.clone())
-                .init_cxx_cfg(cfg)
+                .init_c_cfg(c_cfg)
+                .init_cxx_cfg(cxx_cfg)
                 .define("CMAKE_C_COMPILER", &compiler)
-                .define("CMAKE_CXX_COMPILER", compiler)
+                .define("CMAKE_CXX_COMPILER", &cxx_compiler)
                 .define("CMAKE_TOOLCHAIN_FILE", &self.empty_toolchain_file);
         } else if let Some(target) = &self.cmake_rust_target {
             let mut split = target.split('-');
@@ -688,7 +702,13 @@ impl CMakeConfigurer {
 
     fn derive_forced_c_compiler(&self) -> Option<(PathBuf, bool)> {
         if self.force_clang {
-            Some((PathBuf::from("clang"), false))
+            Some((
+                std::env::var_os("CLANG_PATH")
+                    .filter(|path| !path.is_empty())
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from("clang")),
+                false,
+            ))
         } else {
             match self.target().as_str() {
                 "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => {
@@ -715,6 +735,31 @@ impl CMakeConfigurer {
                 _ => None,
             }
         }
+    }
+
+    /// Maps a C compiler binary onto its C++ counterpart, keeping any directory
+    /// part: `<prefix>gcc` -> `<prefix>g++`, `<prefix>clang` -> `<prefix>clang++`.
+    /// Anything else is returned unchanged.
+    ///
+    /// OpenThread is C++, and the two drivers are not interchangeable: `gcc`
+    /// does compile a `.cpp` correctly (it dispatches on the file extension),
+    /// but it does not link the C++ runtime, so passing the C driver as
+    /// `CMAKE_CXX_COMPILER` only holds while the build stops at static
+    /// archives. The C++ driver is what CMake expects, so give it that.
+    fn cxx_counterpart(c_compiler: &Path) -> PathBuf {
+        let Some(name) = c_compiler.file_name().and_then(|name| name.to_str()) else {
+            return c_compiler.to_path_buf();
+        };
+
+        let cxx_name = if let Some(prefix) = name.strip_suffix("clang") {
+            format!("{prefix}clang++")
+        } else if let Some(prefix) = name.strip_suffix("gcc") {
+            format!("{prefix}g++")
+        } else {
+            return c_compiler.to_path_buf();
+        };
+
+        c_compiler.with_file_name(cxx_name)
     }
 
     fn derive_c_args(&self) -> Vec<String> {
@@ -754,7 +799,7 @@ impl CMakeConfigurer {
                 "riscv32imafc-unknown-none-elf" | "riscv32imafc-esp-espidf" => &[
                     "--target=riscv32-esp-elf",
                     "-march=rv32imafc",
-                    "-mabi=ilp32",
+                    "-mabi=ilp32f",
                 ],
                 "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => {
                     &["--target=xtensa-esp-elf", "-mcpu=esp32"]
@@ -776,7 +821,7 @@ impl CMakeConfigurer {
                     &["-march=rv32imac", "-mabi=ilp32"]
                 }
                 "riscv32imafc-unknown-none-elf" | "riscv32imafc-esp-espidf" => {
-                    &["-march=rv32imafc", "-mabi=ilp32"]
+                    &["-march=rv32imafc", "-mabi=ilp32f"]
                 }
                 "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => &["-mlongcalls"],
                 "xtensa-esp32s2-none-elf" | "xtensa-esp32s2-espidf" => &["-mlongcalls"],


### PR DESCRIPTION
This is the port of the "test with GCC CI fix" from [mbedtls](https://github.com/esp-rs/mbedtls-rs/pull/179)

Additionally, I ported from mbedtls:
- [The build fix for the riscv32imafc target](https://github.com/esp-rs/mbedtls-rs/pull/171)
- Respect `CLANG_PATH` if it is set from https://github.com/esp-rs/mbedtls-rs/pull/130

And a derivation of the C++ compiler from the C one (OpenThread is C++). C++ not strictly necessary, as we don't link C++ stuff (and this is where it matters only), but still best to compile C++ with a C++ compiler.